### PR TITLE
refactor: 알림 컴포넌트 리팩토링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "date-fns": "^2.30.0",
         "framer-motion": "^10.10.0",
         "fslightbox-react": "^1.7.6",
-        "fslightbox-react": "^1.7.6",
         "react": "^18.2.0",
         "react-calendar": "^4.4.0",
         "react-day-picker": "^8.8.0",
@@ -4168,6 +4167,7 @@
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/@types/fslightbox-react/-/fslightbox-react-1.7.3.tgz",
       "integrity": "sha512-6q1n54suIR77dTkvXDNBsd3YNK9k71T7AHgKORybi76i+Un2xYaK27bhcWyH1W/4YK/RUDHLIse1Yl8VnzPVlg==",
+      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -20632,6 +20632,7 @@
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/@types/fslightbox-react/-/fslightbox-react-1.7.3.tgz",
       "integrity": "sha512-6q1n54suIR77dTkvXDNBsd3YNK9k71T7AHgKORybi76i+Un2xYaK27bhcWyH1W/4YK/RUDHLIse1Yl8VnzPVlg==",
+      "dev": true,
       "requires": {
         "@types/react": "*"
       }

--- a/src/components/Alarm/Accept/index.tsx
+++ b/src/components/Alarm/Accept/index.tsx
@@ -1,0 +1,25 @@
+import * as s from "./styles";
+
+const Accept = ({nickname, imglink, time}: any) => {
+  return (
+    <s.Wrapper>
+      <s.ProfileImgWrapper>
+        <s.ProfileImg 
+          src={imglink}
+          alt="profile"
+        />
+        <s.Imoji 
+          src={imglink}
+          alt="imoji"
+        />
+      </s.ProfileImgWrapper>
+
+      <s.ContentsWrapper>
+        <s.MainContents>{nickname}님이 초대를 수락했어요.</s.MainContents>
+        <s.Time>{time}</s.Time>
+      </s.ContentsWrapper>
+    </s.Wrapper>
+  )
+};
+
+export default Accept;

--- a/src/components/Alarm/Accept/styles.ts
+++ b/src/components/Alarm/Accept/styles.ts
@@ -1,0 +1,61 @@
+import styled from "@emotion/styled";
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 274px;
+  height: 86px;
+  min-height: 86px; 
+  border-bottom: 1px solid #c9c9c9;
+  cursor: pointer;
+  flex: 1;
+`;
+
+export const ProfileImgWrapper = styled.div`
+  display: flex;
+  position: relative;
+  justify-content: center;
+  align-items: center;
+  width: 48px;
+  height: 48px;
+`;
+
+export const ProfileImg = styled.img`
+  display: flex;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+`;
+
+export const Imoji = styled.img`
+  position: absolute;
+  top: 28px;
+  left: 28px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 20px;
+  height: 20px;
+  background-color: black;
+`;
+
+export const ContentsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-left: 12px;
+`;
+
+export const MainContents = styled.div`
+  display: flex;
+  font-size: 14px;
+  font-weight: 700;
+  width: 194px;
+`;
+
+export const Time = styled.div`
+  display: flex;
+  font-size: 10px;
+  font-weight: 700;
+  margin-top: 10px;
+`;

--- a/src/components/Alarm/Comment/index.tsx
+++ b/src/components/Alarm/Comment/index.tsx
@@ -1,0 +1,27 @@
+import * as s from "./styles";
+
+const Comment = ({nickname, imglink, time}: any) => {
+  return (
+    <s.Wrapper>
+      <s.ProfileImgWrapper>
+        <s.ProfileImg 
+          src={imglink}
+          alt="profile"
+        />
+        <s.Imoji 
+          src={imglink}
+          alt="imoji"
+        />
+      </s.ProfileImgWrapper>
+
+      <s.ContentsWrapper>
+        <s.MainContents>
+          {nickname}님이 회원님의 게시글에 댓글을 남겼습니다.
+        </s.MainContents>
+        <s.Time>{time}</s.Time>
+      </s.ContentsWrapper>
+  </s.Wrapper>
+  )
+};
+
+export default Comment;

--- a/src/components/Alarm/Comment/styles.ts
+++ b/src/components/Alarm/Comment/styles.ts
@@ -1,0 +1,61 @@
+import styled from "@emotion/styled";
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 274px;
+  height: 86px;
+  min-height: 86px; 
+  border-bottom: 1px solid #c9c9c9;
+  cursor: pointer;
+  flex: 1;
+`;
+
+export const ProfileImgWrapper = styled.div`
+  display: flex;
+  position: relative;
+  justify-content: center;
+  align-items: center;
+  width: 48px;
+  height: 48px;
+`;
+
+export const ProfileImg = styled.img`
+  display: flex;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+`;
+
+export const Imoji = styled.img`
+  position: absolute;
+  top: 28px;
+  left: 28px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 20px;
+  height: 20px;
+  background-color: black;
+`;
+
+export const ContentsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-left: 12px;
+`;
+
+export const MainContents = styled.div`
+  display: flex;
+  font-size: 14px;
+  font-weight: 700;
+  width: 194px;
+`;
+
+export const Time = styled.div`
+  display: flex;
+  font-size: 10px;
+  font-weight: 700;
+  margin-top: 10px;
+`;

--- a/src/components/Alarm/CommentHeart/index.tsx
+++ b/src/components/Alarm/CommentHeart/index.tsx
@@ -1,0 +1,27 @@
+import * as s from "./styles";
+
+const CommentHeart = ({nickname, imglink, time}: any) => {
+  return (
+    <s.Wrapper>
+    <s.ProfileImgWrapper>
+      <s.ProfileImg 
+        src={imglink}
+        alt="profile"
+      />
+      <s.Imoji 
+        src={imglink}
+        alt="imoji"
+      />
+    </s.ProfileImgWrapper>
+
+    <s.ContentsWrapper>
+      <s.MainContents>
+        {nickname}님이 회원님의 댓글을 좋아합니다.
+      </s.MainContents>
+      <s.Time>{time}</s.Time>
+    </s.ContentsWrapper>
+</s.Wrapper>
+  )
+};
+
+export default CommentHeart;

--- a/src/components/Alarm/CommentHeart/styles.ts
+++ b/src/components/Alarm/CommentHeart/styles.ts
@@ -1,0 +1,61 @@
+import styled from "@emotion/styled";
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 274px;
+  height: 86px;
+  min-height: 86px; 
+  border-bottom: 1px solid #c9c9c9;
+  cursor: pointer;
+  flex: 1;
+`;
+
+export const ProfileImgWrapper = styled.div`
+  display: flex;
+  position: relative;
+  justify-content: center;
+  align-items: center;
+  width: 48px;
+  height: 48px;
+`;
+
+export const ProfileImg = styled.img`
+  display: flex;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+`;
+
+export const Imoji = styled.img`
+  position: absolute;
+  top: 28px;
+  left: 28px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 20px;
+  height: 20px;
+  background-color: black;
+`;
+
+export const ContentsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-left: 12px;
+`;
+
+export const MainContents = styled.div`
+  display: flex;
+  font-size: 14px;
+  font-weight: 700;
+  width: 194px;
+`;
+
+export const Time = styled.div`
+  display: flex;
+  font-size: 10px;
+  font-weight: 700;
+  margin-top: 10px;
+`;

--- a/src/components/Alarm/Event/index.tsx
+++ b/src/components/Alarm/Event/index.tsx
@@ -1,0 +1,9 @@
+import * as s from "./styles";
+
+const Event = () => {
+  return (
+    <div>Event</div>
+  )
+};
+
+export default Event;

--- a/src/components/Alarm/Event/styles.ts
+++ b/src/components/Alarm/Event/styles.ts
@@ -1,0 +1,6 @@
+import styled from "@emotion/styled";
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+`;

--- a/src/components/Alarm/Invitation/index.tsx
+++ b/src/components/Alarm/Invitation/index.tsx
@@ -1,0 +1,38 @@
+import { useNavigate } from "react-router";
+import * as s from "./styles";
+
+const Invitation = ({nickname, imglink, time}: any) => {
+  const navigate = useNavigate();
+
+  return (
+    <s.Wrapper>
+      <s.ProfileImgWrapper>
+        <s.ProfileImg 
+          src={imglink}
+          alt="profile"
+        />
+        <s.Imoji 
+          src={imglink}
+          alt="imoji"
+        />
+      </s.ProfileImgWrapper>
+
+      <s.ContentsWrapper>
+        <s.MainContents>
+          {nickname}님이 회원님께 초대장을 전송했습니다.
+        </s.MainContents>
+        <s.BottomContainer>
+          <s.Time>{time}</s.Time>
+          <s.AcceptBtn
+            onClick={() => navigate("/posting")}
+          >수락</s.AcceptBtn>
+          <s.RefuseBtn
+            onClick={() => navigate("/matching")}
+          >거절</s.RefuseBtn>
+        </s.BottomContainer>
+      </s.ContentsWrapper>
+    </s.Wrapper>
+  )
+};
+
+export default Invitation;

--- a/src/components/Alarm/Invitation/styles.ts
+++ b/src/components/Alarm/Invitation/styles.ts
@@ -1,0 +1,102 @@
+import styled from "@emotion/styled";
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 274px;
+  height: 86px;
+  min-height: 86px; 
+  border-bottom: 1px solid #c9c9c9;
+  flex: 1;
+`;
+
+export const ProfileImgWrapper = styled.div`
+  display: flex;
+  position: relative;
+  justify-content: center;
+  align-items: center;
+  width: 48px;
+  height: 48px;
+`;
+
+export const ProfileImg = styled.img`
+  display: flex;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+`;
+
+export const Imoji = styled.img`
+  position: absolute;
+  top: 28px;
+  left: 28px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 20px;
+  height: 20px;
+  background-color: black;
+`;
+
+export const ContentsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-left: 12px;
+`;
+
+export const MainContents = styled.div`
+  display: flex;
+  font-size: 14px;
+  font-weight: 700;
+  width: 194px;
+`;
+
+export const BottomContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  margin-top: 10px;
+  height: 16px;
+  align-items: center;
+`;
+
+export const Time = styled.div`
+  display: flex;
+  font-size: 10px;
+  font-weight: 700;
+`;
+
+export const AcceptBtn = styled.div`
+  display: flex;
+  font-size: 10px;
+  font-weight: 700;
+  margin-left: 10px;
+  border-radius: 10px;
+  color: white;
+  background-color: #804DD3;
+  cursor: pointer;
+
+  padding-left: 10px;
+  padding-right: 10px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  box-sizing: border-box;
+`;
+
+export const RefuseBtn = styled.div`
+  display: flex;
+  font-size: 10px;
+  font-weight: 700;
+  margin-left: 10px;
+  border: 1px solid #797979;
+  border-radius: 10px;
+  color: #797979;
+  background-color: white;
+  cursor: pointer;
+
+  padding-left: 10px;
+  padding-right: 10px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  box-sizing: border-box;
+`;

--- a/src/components/Alarm/Openchat/index.tsx
+++ b/src/components/Alarm/Openchat/index.tsx
@@ -1,0 +1,36 @@
+import { useNavigate } from "react-router";
+import * as s from "./styles";
+
+const Openchat = ({nickname, imglink, time, link}: any) => {
+  const navigate = useNavigate();
+  return (
+    <s.Wrapper>
+      <s.ProfileImgWrapper>
+        <s.ProfileImg 
+          src={imglink}
+          alt="profile"
+        />
+        <s.Imoji 
+          src={imglink}
+          alt="imoji"
+        />
+      </s.ProfileImgWrapper>
+
+      <s.ContentsWrapper>
+        <s.MainContents>
+          {nickname}님의 오픈채팅방 링크가 도착했습니다.
+        </s.MainContents>
+
+        <s.BottomContainer>
+          <s.Time>{time}</s.Time>
+          <s.Link
+            onClick={() => navigate(link)}
+          >이동하기</s.Link>
+        </s.BottomContainer>
+        
+      </s.ContentsWrapper>
+    </s.Wrapper>
+  )
+};
+
+export default Openchat;

--- a/src/components/Alarm/Openchat/styles.ts
+++ b/src/components/Alarm/Openchat/styles.ts
@@ -1,0 +1,85 @@
+import styled from "@emotion/styled";
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 274px;
+  height: 86px;
+  min-height: 86px; 
+  border-bottom: 1px solid #c9c9c9;
+  /* cursor: pointer; */
+  flex: 1;
+`;
+
+export const ProfileImgWrapper = styled.div`
+  display: flex;
+  position: relative;
+  justify-content: center;
+  align-items: center;
+  width: 48px;
+  height: 48px;
+`;
+
+export const ProfileImg = styled.img`
+  display: flex;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+`;
+
+export const Imoji = styled.img`
+  position: absolute;
+  top: 28px;
+  left: 28px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 20px;
+  height: 20px;
+  background-color: black;
+`;
+
+export const ContentsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-left: 12px;
+`;
+
+export const MainContents = styled.div`
+  display: flex;
+  font-size: 14px;
+  font-weight: 700;
+  width: 194px;
+`;
+
+export const BottomContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  margin-top: 10px;
+  height: 16px;
+  align-items: center;
+`;
+
+export const Time = styled.div`
+  display: flex;
+  font-size: 10px;
+  font-weight: 700;
+`;
+
+export const Link = styled.div`
+  display: flex;
+  font-size: 10px;
+  font-weight: 700;
+  margin-left: 10px;
+  border-radius: 10px;
+  color: white;
+  background-color: #804DD3;
+  cursor: pointer;
+
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  box-sizing: border-box;
+`;

--- a/src/components/Alarm/Recomment/index.tsx
+++ b/src/components/Alarm/Recomment/index.tsx
@@ -1,0 +1,27 @@
+import * as s from "./styles";
+
+const Recomment = ({nickname, imglink, time}: any) => {
+  return (
+    <s.Wrapper>
+      <s.ProfileImgWrapper>
+        <s.ProfileImg 
+          src={imglink}
+          alt="profile"
+        />
+        <s.Imoji 
+          src={imglink}
+          alt="imoji"
+        />
+      </s.ProfileImgWrapper>
+
+      <s.ContentsWrapper>
+        <s.MainContents>
+          {nickname}님이 회원님의 댓글에 대댓글을 남겼습니다.
+        </s.MainContents>
+        <s.Time>{time}</s.Time>
+      </s.ContentsWrapper>
+    </s.Wrapper>
+  )
+};
+
+export default Recomment;

--- a/src/components/Alarm/Recomment/styles.ts
+++ b/src/components/Alarm/Recomment/styles.ts
@@ -1,0 +1,61 @@
+import styled from "@emotion/styled";
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 274px;
+  height: 86px;
+  min-height: 86px; 
+  border-bottom: 1px solid #c9c9c9;
+  cursor: pointer;
+  flex: 1;
+`;
+
+export const ProfileImgWrapper = styled.div`
+  display: flex;
+  position: relative;
+  justify-content: center;
+  align-items: center;
+  width: 48px;
+  height: 48px;
+`;
+
+export const ProfileImg = styled.img`
+  display: flex;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+`;
+
+export const Imoji = styled.img`
+  position: absolute;
+  top: 28px;
+  left: 28px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 20px;
+  height: 20px;
+  background-color: black;
+`;
+
+export const ContentsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-left: 12px;
+`;
+
+export const MainContents = styled.div`
+  display: flex;
+  font-size: 14px;
+  font-weight: 700;
+  width: 194px;
+`;
+
+export const Time = styled.div`
+  display: flex;
+  font-size: 10px;
+  font-weight: 700;
+  margin-top: 10px;
+`;

--- a/src/components/Alarm/Refuse/index.tsx
+++ b/src/components/Alarm/Refuse/index.tsx
@@ -1,0 +1,25 @@
+import * as s from "./styles";
+
+const Refuse = ({nickname, imglink, time}: any) => {
+  return (
+    <s.Wrapper>
+      <s.ProfileImgWrapper>
+        <s.ProfileImg 
+          src={imglink}
+          alt="profile"
+        />
+        <s.Imoji 
+          src={imglink}
+          alt="imoji"
+        />
+      </s.ProfileImgWrapper>
+
+      <s.ContentsWrapper>
+        <s.MainContents>{nickname}님이 초대를 거절했어요.</s.MainContents>
+        <s.Time>{time}</s.Time>
+      </s.ContentsWrapper>
+  </s.Wrapper>
+  )
+};
+
+export default Refuse;

--- a/src/components/Alarm/Refuse/styles.ts
+++ b/src/components/Alarm/Refuse/styles.ts
@@ -1,0 +1,61 @@
+import styled from "@emotion/styled";
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 274px;
+  height: 86px;
+  min-height: 86px; 
+  border-bottom: 1px solid #c9c9c9;
+  cursor: pointer;
+  flex: 1;
+`;
+
+export const ProfileImgWrapper = styled.div`
+  display: flex;
+  position: relative;
+  justify-content: center;
+  align-items: center;
+  width: 48px;
+  height: 48px;
+`;
+
+export const ProfileImg = styled.img`
+  display: flex;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+`;
+
+export const Imoji = styled.img`
+  position: absolute;
+  top: 28px;
+  left: 28px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 20px;
+  height: 20px;
+  background-color: black;
+`;
+
+export const ContentsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-left: 12px;
+`;
+
+export const MainContents = styled.div`
+  display: flex;
+  font-size: 14px;
+  font-weight: 700;
+  width: 194px;
+`;
+
+export const Time = styled.div`
+  display: flex;
+  font-size: 10px;
+  font-weight: 700;
+  margin-top: 10px;
+`;

--- a/src/components/Alarm/Report/index.tsx
+++ b/src/components/Alarm/Report/index.tsx
@@ -1,0 +1,9 @@
+import * as s from "./styles";
+
+const Report = () => {
+  return (
+    <div>Report</div>
+  )
+};
+
+export default Report;

--- a/src/components/Alarm/Report/styles.ts
+++ b/src/components/Alarm/Report/styles.ts
@@ -1,0 +1,6 @@
+import styled from "@emotion/styled";
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+`;

--- a/src/components/Alarm/index.tsx
+++ b/src/components/Alarm/index.tsx
@@ -1,197 +1,150 @@
-/** @jsxImportSource @emotion/react */
-import React,{useState} from 'react';
+import React, { useEffect, useState } from 'react';
 import Modal from 'react-modal';
-import { css } from '@emotion/react';
 import * as s from './styles';
-import COLORS from '../../assets/color';
 import useIsMobile from '../../hooks/useIsMobile';
-import { useRecoilState } from 'recoil';
-import { AlarmSwitchState } from '../../recoil/atom/AlarmSwitchState';
-//알람 상태관리필요 ( useEffect : 매칭 컴포넌트부터)
-const alarmTabState = true;
+import AlarmCloseIcon from "../../images/components/Alarm/AlarmCloseIcon.svg";
+import { useNavigate } from 'react-router';
+import Comment from './Comment';
+import Recomment from './Recomment';
+import CommentHeart from './CommentHeart';
+import Invitation from './Invitation';
+import Openchat from './Openchat';
+import Accept from './Accept';
+import Refuse from './Refuse';
+import Report from './Report';
+import Event from './Event';
 
-//dummy데이터
-const textData = [
-  { id: 1, userName: "개죽이", text: "님이 회원님의 게시글에 댓글을 남겼습니다. 회원님의 게시글에 HIHI asdad", time: '2시간 전'},
-  { id: 2, userName: "애옹", text: "님이 회원님께 초대장을 전송했습니다.!", time: '1시간 전',},
-  { id: 3, userName: "망고", text: "님이 회원님의 대댓글을 좋아합니다.", time: '1시간 전',},
-  { id: 4, userName: "고냥이", text: "님이 회원님의 게시글에 댓글을 남겼습니다. 회원님의 게시글에 SAY Hellooooo asap!", time: '1시간 전',},
+const tmpAlarmData = [
+  {nickname: "애옹이", type: "COMMENT", imglink: "https://i.imgur.com/fsyrScY.jpg", time: "1시간 전"},
+  {nickname: "개죽이", type: "RECOMMENT", imglink: "https://i.imgur.com/fsyrScY.jpg", time: "1시간 전"},
+  {nickname: "시면준", type: "COMMENTHEART", imglink: "https://i.imgur.com/fsyrScY.jpg", time: "1시간 전"},
+  {nickname: "망고조아", type: "INVITATION", imglink: "https://i.imgur.com/fsyrScY.jpg", time: "1시간 전"},
+  {nickname: "애옹이", type: "OPENCHAT", imglink: "https://i.imgur.com/fsyrScY.jpg", time: "1시간 전", link: "https://naver.com"},
+  {nickname: "시면준아프지마", type: "ACCEPT", imglink: "https://i.imgur.com/fsyrScY.jpg", time: "1시간 전"},
+  {nickname: "재모기", type: "REFUSE", imglink: "https://i.imgur.com/fsyrScY.jpg", time: "1시간 전"},
+  {nickname: "", type: "REPORT", imglink: "", time: "1시간 전"},
+  {nickname: "", type: "EVENT", imglink: "", time: "1시간 전"},
+  {nickname: "애옹이", type: "COMMENT", imglink: "https://i.imgur.com/fsyrScY.jpg", time: "2시간 전"},
+  {nickname: "개죽이", type: "RECOMMENT", imglink: "https://i.imgur.com/fsyrScY.jpg", time: "2시간 전"},
+  {nickname: "시면준", type: "COMMENTHEART", imglink: "https://i.imgur.com/fsyrScY.jpg", time: "2시간 전"},
+  {nickname: "망고조아", type: "INVITATION", imglink: "https://i.imgur.com/fsyrScY.jpg", time: "2시간 전"},
+  {nickname: "애옹이", type: "OPENCHAT", imglink: "https://i.imgur.com/fsyrScY.jpg", time: "2시간 전", link: "https://naver.com"},
+  {nickname: "시면준아프지마", type: "ACCEPT", imglink: "https://i.imgur.com/fsyrScY.jpg", time: "2시간 전"},
+  {nickname: "재모기", type: "REFUSE", imglink: "https://i.imgur.com/fsyrScY.jpg", time: "2시간 전"},
+  {nickname: "", type: "REPORT", imglink: "", time: "2시간 전"},
+  {nickname: "", type: "EVENT", imglink: "", time: "2시간 전"},
 ];
 
+const CustomModalAlarm: React.FC<ReactModal.Props> = ({ isOpen, onRequestClose }) => {
 
-//알람 모달컴포넌트
-const CustomModalAlarm: React.FC<ReactModal.Props> = ({isOpen, onRequestClose}) => {
-  //알람 recoil 상태관리 
-  const [openState,setOpenState] =useRecoilState(AlarmSwitchState);
-  const closeAlarm = ()=>{
-    setOpenState(!openState)
-  };
+  const navigate = useNavigate();
+
   const isMobile = useIsMobile();
-   const AlarmStyles1:ReactModal.Styles = 
-  { 
-  overlay: {
-  position: 'fixed',
-  top: 0,
-  left: 0,
-  right: 0,
-  bottom: 0,
-  backgroundColor: 'rgba(0, 0, 0, 0.2)',
-  zIndex: 10,
-},
-content: {
-  display:'flex',
-  width:'333px',
-  height:'470px',
-  justifyContent:'center',
-  top: '122px',
-  left:0,
-  right: 0,
-  bottom:0,
-  zIndex: 10,
-  borderRadius:'1rem',
-  padding:'0',
-  margin:'0 auto',
-  maxWidth: '100vw',
-  overflow:'hidden',
-}};
+  const AlarmStyles = isMobile ? s.MobileModalStyle : s.WebModalStyle;
 
- const AlarmStyles2:ReactModal.Styles = 
-  { 
-  overlay: {
-  position: 'fixed',
-  top: 0,
-  left: 0,
-  right: 0,
-  bottom: 0,
-  backgroundColor: 'rgba(0, 0, 0, 0.2)',
-  zIndex: 10,
-},
-content: {
-  display:'flex',
-  width:'333px',
-  height:'470px',
-  justifyContent:'center',
-  top: '78px',
-  left: 570,
-  right: 0,
-  bottom:0,
-  zIndex: 10,
-  borderRadius:'1rem',
-  padding:'0',
-  margin:'0 auto',
-  maxWidth: '100vw',
-  overflow:'hidden',
-}};
-const AlarmStyles = isMobile ? AlarmStyles1 : AlarmStyles2;
+  const onClickProfileBtn = () => {
+    navigate("/profile");
+  };
+
+  const [isTabLeft, setIsTabLeft] = useState(true);
+  const onClickLeftTab = () => {
+    setIsTabLeft(true);
+  };
+  const onClickRightTab = () => {
+    setIsTabLeft(false);
+  };
+
+  if(isMobile) {
+    return (
+      <Modal
+        isOpen={isOpen}
+        onRequestClose={onRequestClose}
+        style={AlarmStyles}
+      >
+
+      </Modal>
+    )
+  }
 
 
   return (
-  <Modal
-      isOpen={openState}
-      onRequestClose={onRequestClose}
-      style={AlarmStyles}
-    >
-      <s.AlarmModalWrapper>
-        <s.AlarmTopBar>
-        <div css={css`width:100%;
-        `}>알림</div>
-        <div onClick={closeAlarm} css={css`&:after {content: "\\00d7"; font-size:25pt;
-      font-weight:500;      
-      }`}></div>
-        </s.AlarmTopBar>
-        
-        <s.AlarmTabWrapper>
-          <s.AlarmTab>
-          <div css={css`width:50%; font-size:18px;
-          font-weight: ${alarmTabState? 900 : 500};
-          padding-bottom:10px;
-          color: ${alarmTabState? COLORS.main100 : '#black'};
-          border-bottom: ${alarmTabState? '3px' :'2px'} solid ${alarmTabState? COLORS.main79 : '#C9C9C9'};
-          `}>매칭</div>
+      <Modal
+        isOpen={isOpen}
+        onRequestClose={onRequestClose}
+        style={AlarmStyles}
+      >
+        <s.AlarmModalWrapper>
+          <s.AlarmTopBar>
+            <s.AlarmTopBarText>알림</s.AlarmTopBarText>
+            <s.AlarmCloseIconWrapper>
+              <s.AlarmCloseBtn 
+                src={AlarmCloseIcon}
+                alt='close'
+                onClick={onRequestClose}
+              />
+            </s.AlarmCloseIconWrapper>
+          </s.AlarmTopBar>
 
-        <div css={css`width:50%; font-size:18px;
-          font-weight: ${!alarmTabState? 900 : 500};
-          padding-bottom:10px;
-          color: ${!alarmTabState? COLORS.main100 : '#black'};
-          border-bottom: ${!alarmTabState? '3px' :'2.3px'} solid ${!alarmTabState? COLORS.main79 : '#C9C9C9'};
-          `}>공지사항</div>
-          </s.AlarmTab>
-          
-        {/* 알람컨텐츠 */}
-          <s.AlarmContentsWrapper>
-          {
-            textData.map((item,idx)=>{
-              return (
-          <s.AlarmContent>        
-            <div css={css`width:48px; height:48px;
-            background:gray; border-radius:50%;`}>
-              <div css={css`background:purple;
-              z-index: 11;
-              border-radius:50%;
-              width:1.1rem; height:1.1rem;
-              position:relative;
-              top:30px;
-             left:33px;`}>
-             </div>
-            </div>
-            <div css={css`
-            position:relative;
-            bottom:3px;
-            max-width:195px;
-            grid-column: 2 / 5;
-            word-wrap:word-break;
-            line-height:18px;
-            letter-spacing:-2%;
-            font-weight:500;
-            font-size:14px;
-            `}><span css={css`font-weight:700;`}>{item.userName}</span>{item.text}</div>
-
-            <div css={css`grid-column:2;
-            font-size: 10px;
-            font-weight:700;
-            position:relative;
-            top:2.5px;
-            color:${COLORS.Gray3};
-            `}>{item.time}</div>
-            <div css={css`
-            grid-column:3;
-            display:flex;
-            align-items:center;
-            justify-content:center;
-            color:white;
-            font-size: 10px;
-            font-weight:700;
-            position:relative;
-            right:1.8rem;
-            width:42px;
-            height:16px;
-            border-radius: 12px;
-            box-sizing:border-box;
-            background:${COLORS.main100};
-            &:hover{${s.AcceptButtonHoverCss}};
-            `}>수락</div>
-            <div css={css`
-          grid-column:4;
-          display:flex;
-          align-items:center;
-          justify-content:center;
-          color:${COLORS.Gray3};
-          border: 1px solid ${COLORS.Gray3};
-          font-size: 10px;
-          font-weight:700;
-          position:relative;
-          right:3.8rem;
-          width:42px;
-          height:16px;
-          border-radius: 12px;
-          box-sizing:border-box;
-          &:hover{${s.AcceptButtonHoverCss}};
-            `}>거절</div>
-          </s.AlarmContent>)})}
-          </s.AlarmContentsWrapper>
-        </s.AlarmTabWrapper>
-      </s.AlarmModalWrapper>
-    </Modal>
+          <s.AlarmBottom>
+            {
+              isTabLeft ?
+              <s.TabContainerLeft>
+                <s.Tabs>
+                  <s.Left1>매칭</s.Left1>
+                  <s.Right1 onClick={onClickRightTab}>공지사항</s.Right1>
+                </s.Tabs>
+                <s.AlarmList>
+                  {
+                    tmpAlarmData.map((data) => {
+                      if(data.type === "COMMENT"){
+                        return <Comment nickname={data.nickname} imglink={data.imglink} time={data.time}/>
+                      }
+                      if(data.type === "RECOMMENT"){
+                        return <Recomment nickname={data.nickname} imglink={data.imglink} time={data.time}/>
+                      }
+                      if(data.type === "COMMENTHEART"){
+                        return <CommentHeart nickname={data.nickname} imglink={data.imglink} time={data.time}/>
+                      }
+                      if(data.type === "INVITATION"){
+                        return <Invitation nickname={data.nickname} imglink={data.imglink} time={data.time}/>
+                      }
+                      if(data.type === "OPENCHAT"){
+                        return <Openchat nickname={data.nickname} imglink={data.imglink} time={data.time} link={data.link}/>
+                      }
+                      if(data.type === "ACCEPT"){
+                        return <Accept nickname={data.nickname} imglink={data.imglink} time={data.time}/>
+                      }
+                      if(data.type === "REFUSE"){
+                        return <Refuse nickname={data.nickname} imglink={data.imglink} time={data.time}/>
+                      }
+                      return null;
+                    })
+                  }
+                </s.AlarmList>
+              </s.TabContainerLeft> :
+              <s.TabContainerRight>
+                <s.Tabs>
+                  <s.Left2 onClick={onClickLeftTab}>매칭</s.Left2>
+                  <s.Right2>공지사항</s.Right2>
+                </s.Tabs>
+                <s.AlarmList>
+                  {
+                    tmpAlarmData.map((data) => {
+                      // if(data.type === "REPORT"){
+                      //   return <Report nickname={data.nickname} imglink={data.imglink} time={data.time}/>
+                      // }
+                      // if(data.type === "EVENT"){
+                      //   return <Event nickname={data.nickname} imglink={data.imglink} time={data.time}/>
+                      // }
+                      return null;
+                    })
+                  }
+                </s.AlarmList>
+              </s.TabContainerRight>
+            }
+          </s.AlarmBottom>
+        </s.AlarmModalWrapper>
+      </Modal>
   );
 };
 

--- a/src/components/Alarm/styles.ts
+++ b/src/components/Alarm/styles.ts
@@ -1,67 +1,170 @@
-/** @jsxImportSource @emotion/react */
 import styled from '@emotion/styled';
-import COLORS from '../../assets/color';
-import { css } from '@emotion/react';
+
+export const MobileModalStyle: ReactModal.Styles = {
+  overlay: {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: 'rgba(0, 0, 0, 0.2)',
+    zIndex: 10,
+  },
+  content: {
+    display: 'flex',
+    width: '420px',
+    height: '400px',
+    justifyContent: 'center',
+    top: '122px',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    zIndex: 10,
+    borderRadius: '1rem',
+    padding: '0',
+    margin: '0 auto',
+    maxWidth: '100vw',
+    overflow: 'hidden',
+  }
+};
+
+export const WebModalStyle: ReactModal.Styles = {
+  overlay: {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: 'rgba(0, 0, 0, 0.2)',
+    zIndex: 10,
+  },
+  content: {
+    display: 'flex',
+    width: '330px',
+    height: '460px',
+    justifyContent: 'center',
+    top: '78px',
+    left: 570,
+    right: 0,
+    bottom: 0,
+    zIndex: 10,
+    borderRadius: '1rem',
+    padding: '0',
+    margin: '0 auto',
+    maxWidth: '100vw',
+    overflow: 'hidden',
+  }
+};
+
 export const AlarmModalWrapper = styled.div`
-display:flex;
-flex-direction:column;
-width:100%;
-`
-export const AlarmTopBar =styled.div`
-display:flex;
-justify-content:space-between;
-height:60px;
-background: ${COLORS.main79};
-padding: 20px 20px 20px 20px;
-font-size: 22px;
-font-weight: 900;
-line-height:100%;
-color:white;
-box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
+export const AlarmTopBar = styled.div`
+  display: flex;
+  justify-content: space-between;
+  height: 60px;
+  background: #804DD3;
+  font-size: 18px;
+  font-weight: 600;
+  color: white;
 ;`
 
-export const AlarmTab = styled.div`
-display:flex;
-justify-content:space-between;
+export const AlarmTopBarText = styled.div`
+  display: flex;
+  margin-top: 20px;
+  margin-left: 20px;
 `;
 
-//알람 탭과 컨텐츠를 포함하는 wrapper 
-export const AlarmTabWrapper = styled.div`
-box-sizing:border-box;
-width:100%;
-padding:20px;
+export const AlarmCloseIconWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 16px;
+  margin-right: 20px;
+  width: 28px;
+  height: 28px;
+  cursor: pointer;
 `;
 
+export const AlarmCloseBtn = styled.img`
+  display: flex;
+`;
 
-//알람 컨텐츠
+export const AlarmBottom = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 330px;
+`;
 
-export const AlarmContentsWrapper =styled.div`
-max-width:310px;
-max-height: 320px;
-overflow-x:hidden;
-overflow-y:scroll;
-`
+export const TabContainerLeft = styled.div`
+  display: flex;
+  flex-direction: column;
+  max-height: 406px;
+`;
 
-export const AlarmContent = styled.div`
-width:100%;
-padding: 1rem 0 1rem 0;
-display:grid;
-grid-gap: 0px 12px;
-grid-template-columns:48px;
-grid-auto-columns: repeat(3,1fr);
-border-bottom: 1px solid ${COLORS.Gray2}
-`
-export const AcceptButtonWrapper = styled.div`
-width:90px;
-height:1rem;
-display:flex;
-justify-content:space-between;
-`
-export const AcceptButtonHoverCss = css`
-@media (hover: hover) { 
-  &:hover {
-    color: white;
-    background:${COLORS.sub_Friend};
-    font-weight: 900;
-  }
-`
+export const TabContainerRight = styled.div`
+  display: flex;
+  flex-direction: column;
+  max-height: 406px;
+`;
+
+export const Tabs = styled.div`
+  display: flex;
+  flex-direction: row;
+  width: 290px;
+  height: 30px;
+  margin-top: 19px;
+`;
+
+export const Left1 = styled.div`
+  display: flex;
+  align-items: center;
+  width: 50%;
+  font-size: 18px;
+  font-weight: 800;
+  color: #5e1ec7;
+  border-bottom: 2px solid #5E1EC7;
+  cursor: pointer;
+`;
+
+export const Right1 = styled.div`
+  display: flex;
+  align-items: center;
+  width: 50%;
+  font-size: 18px;
+  font-weight: 500;
+  border-bottom: 1px solid #C9C9C9;
+  cursor: pointer;
+`;
+
+export const Left2 = styled.div`
+  display: flex;
+  align-items: center;
+  width: 50%;
+  font-size: 18px;
+  font-weight: 500;
+  border-bottom: 1px solid #c9c9c9;
+  cursor: pointer;
+`;
+
+export const Right2 = styled.div`
+  display: flex;
+  align-items: center;
+  width: 50%;
+  font-size: 18px;
+  font-weight: 800;
+  color: #5e1ec7;
+  border-bottom: 2px solid #5E1EC7;
+  cursor: pointer;
+`;
+
+export const AlarmList = styled.div`
+  display: flex;
+  flex-direction: column;
+  overflow: auto;
+  height: 338px;
+`;

--- a/src/components/Common/Header/index.tsx
+++ b/src/components/Common/Header/index.tsx
@@ -1,13 +1,12 @@
 import { useEffect, useState } from 'react';
 import { IHeaderCategory } from '../../../interfaces/IHeaderCategories';
 import { useNavigate, useLocation } from "react-router-dom";
-import * as s from "./styles";
 import HibitLogo from "../../../images/components/HibitLogo.svg";
 import AlarmIcon from "../../../images/components/AlarmIcon.svg";
 import useIsMobile from '../../../hooks/useIsMobile';
 import LoginModal from '../../Login/LoginModal';
-import { useRecoilState } from 'recoil';
-import { AlarmSwitchState } from '../../../recoil/atom/AlarmSwitchState';
+import CustomModalAlarm from '../../Alarm';
+import * as s from "./styles";
 
 const CATEGORIES: IHeaderCategory[] = [
   { title: "서비스 소개", link: "/intro" },
@@ -20,11 +19,16 @@ const Header = () => {
   const { pathname } = useLocation();
   const [selectedCategory, setSelectedCategory] = useState<string>("메인");
   const [isLogin, setIsLogin] = useState<boolean>(true);
-  const [isAlarm, setIsAlarm] = useState<boolean>(true);
-  const [alarmCount, setAlarmCount] = useState<number>(3);
+  const [hasAlarm, setHasAlarm] = useState<boolean>(true);
+  const [alarmCount, setAlarmCount] = useState<number>(14);
   
-  const [alarmState,setAlarmState] = useRecoilState<boolean>(AlarmSwitchState);
-  const onAlarmState = ()=>setAlarmState(!alarmState)
+  // const [alarmState, setAlarmState] = useRecoilState<boolean>(AlarmSwitchState);
+  // const onAlarmState = ()=>setAlarmState(!alarmState)
+  const [isAlarmOpen, setIsAlarmOpen] = useState<boolean>(false);
+  const onClickAlarm = () => {
+    setIsAlarmOpen(!isAlarmOpen);
+    console.log({isAlarmOpen});
+  };
 
   const [modalOpen, setModalOpen] = useState(false);
   const openModal = () => {
@@ -37,8 +41,8 @@ const Header = () => {
   };
 
   useEffect(() => {
-    if (alarmCount === 0) setIsAlarm(false);
-    else setIsAlarm(true);
+    if (alarmCount === 0) setHasAlarm(false);
+    else setHasAlarm(true);
   }, [alarmCount]);
 
   const onClickLogin = () => {
@@ -102,12 +106,18 @@ const Header = () => {
       {isLogin ?
         <s.RightContainer>
           <s.AlarmLogoContainer>
-            <img onClick={onAlarmState} src={AlarmIcon} alt='alarm-icon' />
-            {isAlarm ? 
+            <img onClick={onClickAlarm} src={AlarmIcon} alt='alarm-icon' />
+            {
+              hasAlarm ?
               <s.AlarmCountWrapper>{alarmCount}</s.AlarmCountWrapper>
               : <></>
             }
+            
           </s.AlarmLogoContainer>
+          <CustomModalAlarm 
+            isOpen={isAlarmOpen}
+            onRequestClose={onClickAlarm}
+          />
           <s.TextWrapper onClick={() => onClickLogout()}>로그아웃</s.TextWrapper>
         </s.RightContainer> :
         <s.RightContainer>

--- a/src/images/components/Alarm/AlarmCloseIcon.svg
+++ b/src/images/components/Alarm/AlarmCloseIcon.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15 1L1 15M1 1L15 15" stroke="white" stroke-width="1.16667" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -3,7 +3,6 @@ import LayoutTemplate from '../../components/Common/LayoutTemplate';
 import MainTab from '../../components/Main/MainTab';
 import useIsMobile from "../../hooks/useIsMobile";
 import { useRecoilState } from "recoil";
-import { AlarmSwitchState } from "../../recoil/atom/AlarmSwitchState";
 import { toggleNavState } from "../../recoil/atom/ToggleNavState";
 import MoHeaderComponent from "../../components/Main/Mobile/MobileHeader";
 import MobileNavbar from "../../components/Main/Mobile/MobileNavbar";
@@ -11,28 +10,23 @@ import MobileTab from "../../components/Main/Mobile/MobileTab";
 import MobileSlider from "../../components/Main/Mobile/MobileSlider";
 import CustomModalAlarm from "../../components/Alarm";
 const MainPage = () => {
-  const [toggleState,setToggleState] = useRecoilState<boolean>(toggleNavState);
-  const onToggle: Function = ()=>{
+  const [toggleState, setToggleState] = useRecoilState<boolean>(toggleNavState);
+  const onToggle: Function = () => {
     setToggleState(!toggleState);
   }
-  //알람 상태관리
-  const [alarmState,setAlarmState] = useRecoilState<boolean>(AlarmSwitchState);
-  const onAlarmState = ()=>setAlarmState(!alarmState)
 
-  if(useIsMobile()){
-    if(toggleState){
+  if (useIsMobile()) {
+    if (toggleState) {
       //on-off구현
       return (
-        <> 
+        <>
           <MoHeaderComponent onToggle={onToggle} ></MoHeaderComponent>
-          <MobileNavbar></MobileNavbar> 
+          <MobileNavbar></MobileNavbar>
         </>
       )
     }
-    return(
-      <>    <CustomModalAlarm isOpen={alarmState}
-      onRequestClose={onAlarmState} 
-     ></CustomModalAlarm>
+    return (
+      <>    
         <MoHeaderComponent onToggle={onToggle}></MoHeaderComponent>
         <MobileTab></MobileTab>
         <MobileSlider></MobileSlider>
@@ -41,9 +35,6 @@ const MainPage = () => {
   }
   return (
     <LayoutTemplate>
-    <CustomModalAlarm isOpen={alarmState}
-      onRequestClose={onAlarmState} 
-     ></CustomModalAlarm>
       <MainTab></MainTab>
       <s.Wrapper>
         {/* <GoogleLoginButton /> */}


### PR DESCRIPTION
## 작업 내용
> 알림 컴포넌트 리팩토링
resolves #32 

<br/>

## 변동 내용
> 1. 기존 메인 페이지에서만 알림이 렌더링 되던 이슈 해결을 위해, Header 컴포넌트에서 상태관리하는 로직으로 변경
> 2. Recoil 상태관리 미사용
> 3. 공지사항 탭 추가 구현
> 4. Alarm 종류 별 다른 렌더링 및 재사용성을 위해, 각 알림 종류 별 컴포넌트 분
<br/>

## 자료 첨부
> ![image](https://github.com/hibit-team/hibit-frontend/assets/77184523/9bd16e89-2c87-4dee-938c-fdc0969bc4e8)
> ![image](https://github.com/hibit-team/hibit-frontend/assets/77184523/b46e40b3-a526-4bd1-8ce0-068b80b899de)
> ![image](https://github.com/hibit-team/hibit-frontend/assets/77184523/1c8f3573-b29a-4854-b9ac-7aff2a95b1e0)


<br/>

## 중점으로 리뷰받고 싶은 내용
> 리뷰 받고 싶은 내용이 있다면 작성해주세요.

<br/>

## 참고자료
> 참고한 자료를 첨부해주세요. 
