### PR TITLE
QA: 신고하기, 리디렉션 에러 및 기타 수정

### DIFF
--- a/src/components/MatchPost/PostArticle/index.tsx
+++ b/src/components/MatchPost/PostArticle/index.tsx
@@ -462,7 +462,7 @@ export const PostOptionComponent = ({
               switch (opt[1]) {
                 case 0: {
                   //수정 라우트로 이동
-                  navigate('/matching');
+                  navigate(`/put-posting/${postIDX}`);
                   break;
                 }
                 //삭제

--- a/src/components/MatchPost/ReportModal/index.tsx
+++ b/src/components/MatchPost/ReportModal/index.tsx
@@ -11,8 +11,10 @@ import { useRecoilState, useRecoilValue } from 'recoil';
 import { ReportSelectOptionAtom } from '../../../recoil/atom/ReportSelectOptionAtom';
 import { motion } from 'framer-motion';
 import { usePostReport } from '../../../hooks/MatchingPost/usePostReport';
+import HttpClient from '../../../services/HttpClient';
 
 export default function ReportModal() {
+  const [userId,setUserId] = useState<string>('');
   const params = useParams();
   //게시글넘버
   const postIdx = params.idx;
@@ -46,14 +48,25 @@ export default function ReportModal() {
     '기타',
   ];
 
-  const { mutate } = usePostReport({
-    userId: 'a', //str
-    reportId: 'b', //str
+    const { mutate } = usePostReport({
+    userId: userId ? userId : 'error', //userId
     postIdx: !postIdx ? null : Number.parseInt(postIdx),
     commentIdx: !commentIdx ? null : Number.parseInt(commentIdx),
     declarationType: selectedOpt !== null ? declarationTypeArray[selectedOpt] : null,
     content: reportText,
   });
+  useEffect(() => {
+    const fetchUserId = async () => {
+      try {
+        const fetchedUserId = await HttpClient.get('/api/profiles/me');
+        setUserId(fetchedUserId);
+      } catch (e) {
+        console.error(e,'userId를 받아오지 못했습니다.');
+      }
+    };
+    fetchUserId()
+  },[])
+  console.log(userId)
   return (
     <div
       css={{

--- a/src/components/MatchPost/ReportModal/index.tsx
+++ b/src/components/MatchPost/ReportModal/index.tsx
@@ -59,7 +59,7 @@ export default function ReportModal() {
     const fetchUserId = async () => {
       try {
         const fetchedUserId = await HttpClient.get('/api/profiles/me');
-        setUserId(fetchedUserId);
+        setUserId(fetchedUserId.id);
       } catch (e) {
         console.error(e,'userId를 받아오지 못했습니다.');
       }

--- a/src/components/Matching/SearchBar/index.tsx
+++ b/src/components/Matching/SearchBar/index.tsx
@@ -6,7 +6,21 @@ import React, { useState, useRef ,useEffect } from 'react';
 import SearchIcon from '../../../images/components/Matching/searchIcon.svg';
 import { useSetRecoilState } from 'recoil';
 import { MatchingControllerState } from '../../../recoil/atom/MatchingControllerState';
+import HttpClient from '../../../services/HttpClient';
+
 const CustomSearchBar = () => {
+  let [userId,setUserId] = useState<string>('');
+  useEffect(() => {
+    const fetchUserId = async () => {
+      try {
+        const fetchedUserId = await HttpClient.get('/api/profiles/me');
+        setUserId(fetchedUserId.id);
+      } catch (e) {
+        console.error(e,'userId를 받아오지 못했습니다.');
+      }
+    };
+    fetchUserId()
+  },[userId])
   const inputRef = useRef<HTMLInputElement>(null);
   const [inputValue, setInputValue] = useState('');
   const [placeHolderState, setPlaceHolderState] = useState(true);
@@ -25,9 +39,10 @@ const CustomSearchBar = () => {
         font-size: 22px;
         font-weight: 500px;
         position: relative;
-        right: 6rem;
+        right: 2rem;
         bottom: 5.45rem;
         height: 0;
+        left: auto;
       `}
     >
       <span
@@ -41,7 +56,7 @@ const CustomSearchBar = () => {
             font-weight: 700;
           `}
         >
-          히순이
+          {userId ? userId : '익명'}
         </span>
         님 👋
       </span>

--- a/src/hooks/MatchingPost/usePostReport.ts
+++ b/src/hooks/MatchingPost/usePostReport.ts
@@ -1,11 +1,10 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import HttpClient from '../../services/HttpClient';
-import { AxiosError } from 'axios';
+import { AxiosError} from 'axios';
 import { useNavigate } from 'react-router-dom';
 
 export interface IReportBody {
   userId: string;
-  reportId: string;
   postIdx: number | null;
   commentIdx: number | null;
   declarationType: string | null;

--- a/src/pages/MatchPost/index.tsx
+++ b/src/pages/MatchPost/index.tsx
@@ -69,7 +69,7 @@ export default function MatchingPostPage() {
   };
   const { data, isError, error, isLoading, isFetching, status } = useQuery<IMatchingPostPage, AxiosError>(['post-info'], getPostInfoFn, {
     staleTime: 1000,
-    retry: 3,
+    retry: 1,
     retryDelay: 2000,
   },);
 

--- a/src/pages/Posting/PutPosting/index.tsx
+++ b/src/pages/Posting/PutPosting/index.tsx
@@ -18,6 +18,8 @@ import { IImage } from "../../../interfaces/IImage";
 import { IGetPosting, IPosting } from "../../../interfaces/Posting/IPosting";
 import PostingAPI from "../../../api/PostingAPI";
 import calendarCloseBtn from "../../../images/components/Posting/calendarCloseBtn.svg";
+import HttpClient from "../../../services/HttpClient";
+import { AxiosError,AxiosResponse} from "axios";
 
 const activityData_Imoji = [
   "맛집 가기😋", "카페 가기☕", "전시만 보기👓", "만나서 정해요!"
@@ -37,11 +39,30 @@ interface IExhibition {
 };
 const OPENCHAT_GUIDELINK = "https://cs.kakao.com/helps_html/1073184404?locale=ko";
 
-const PutPosting = () => {
+const PutPosting = () => { 
   const isMobile = useIsMobile();
   const navigate = useNavigate();
   const { idx } = useParams();
-
+  useEffect(()=>{
+    const isWriterCorrect = async ()=>{
+      try{
+        const { postIdx } = useParams();
+        const {writerIdx} = await HttpClient.get(`/post/${postIdx}`) //
+        const {id : userIdx} = await  HttpClient.get('/api/members/me')
+        console.log('test',userIdx,writerIdx)
+        if( userIdx !== writerIdx ){
+          //만약 해당 게시글의 작성자idx와 본인의Idx가 일치하지않는다면
+          navigate('/matching')
+        }
+      } catch(e){
+        // 에러발생시
+        console.log('과연 두번 이펙트가 발생?')
+        navigate('/matching')
+        console.error(`${(e as AxiosError)}: userIdx를 불러올 수 없습니다`)
+      }
+    }
+    isWriterCorrect()
+  },[idx])
   const [title, setTitle] = useState<string>("");
   const onChangeTitle = (e: ChangeEvent<HTMLInputElement>) => {
     if(e.target.value.length >= 31) {
@@ -323,7 +344,6 @@ const PutPosting = () => {
         console.error({e});
       })
   }, []);
-
 
 
   const onClickSubmitBtn = () => {


### PR DESCRIPTION
## 작업 내용
> 
- 매칭메인페이지 게시글 서치바에 이름 수정 (’히순이’ → 유저 nickname , 만약 로그인한 유저가 아니라면 ‘익명’ )

- 신고하기 reportId파라미터 삭제했고 , userId파라미터에 `api/profiles/me` API에서 받아오는유저 닉네임값 담아서 post하는 걸로 수정
- 게시글 수정하기 클릭시 매칭 메인페이지로 이동하던 문제 해결 ⇒ post-posting:게시글넘버 주소로 리디렉션 시키게 수정했습니다.
    - 게시글 수정컴포넌트(put-posting/:idx)에서 주소창으로 비정상적인 접근시 타인의 게시글 작성 정보를 확인한다거나 수정하는 어뷰징이 발생할 수 있어서 아래의 로직을 추가했습니다. 
    1. 해당 게시글넘버의 작성자idx와 본인 유저idx를 비동기요청을 통해 받아와서 이 둘을 비교하고 만약 값이 틀리거나 API요청에 에러가 발생한다면 /matching 라우트로 이동하게 구현했는데 현재 주소창에서 라우트를 직접 변경시 로그인이 refresh되어 API UnAuthorized가 발생하므로 무조건 matching으로 이동합니다. 추후 로그인 로직 전부 수정되면 다시 테스트해보면 좋을 것 같습니다!

