### PR TITLE
QA: 신고하기, 리디렉션 에러 및 기타 수정

### DIFF
--- a/src/components/MatchPost/PostArticle/index.tsx
+++ b/src/components/MatchPost/PostArticle/index.tsx
@@ -462,7 +462,7 @@ export const PostOptionComponent = ({
               switch (opt[1]) {
                 case 0: {
                   //수정 라우트로 이동
-                  navigate('/matching');
+                  navigate(`/put-posting/${postIDX}`);
                   break;
                 }
                 //삭제

--- a/src/components/MatchPost/ReportModal/index.tsx
+++ b/src/components/MatchPost/ReportModal/index.tsx
@@ -11,8 +11,10 @@ import { useRecoilState, useRecoilValue } from 'recoil';
 import { ReportSelectOptionAtom } from '../../../recoil/atom/ReportSelectOptionAtom';
 import { motion } from 'framer-motion';
 import { usePostReport } from '../../../hooks/MatchingPost/usePostReport';
+import HttpClient from '../../../services/HttpClient';
 
 export default function ReportModal() {
+  const [userId,setUserId] = useState<string>('');
   const params = useParams();
   //게시글넘버
   const postIdx = params.idx;
@@ -46,14 +48,25 @@ export default function ReportModal() {
     '기타',
   ];
 
-  const { mutate } = usePostReport({
-    userId: 'a', //str
-    reportId: 'b', //str
+    const { mutate } = usePostReport({
+    userId: userId ? userId : 'error', //userId
     postIdx: !postIdx ? null : Number.parseInt(postIdx),
     commentIdx: !commentIdx ? null : Number.parseInt(commentIdx),
     declarationType: selectedOpt !== null ? declarationTypeArray[selectedOpt] : null,
     content: reportText,
   });
+  useEffect(() => {
+    const fetchUserId = async () => {
+      try {
+        const fetchedUserId = await HttpClient.get('/api/profiles/me');
+        setUserId(fetchedUserId);
+      } catch (e) {
+        console.error(e,'userId를 받아오지 못했습니다.');
+      }
+    };
+    fetchUserId()
+  },[])
+  console.log(userId)
   return (
     <div
       css={{

--- a/src/components/MatchPost/ReportModal/index.tsx
+++ b/src/components/MatchPost/ReportModal/index.tsx
@@ -16,23 +16,19 @@ import HttpClient from '../../../services/HttpClient';
 export default function ReportModal() {
   const [userId,setUserId] = useState<string>('');
   const params = useParams();
-  //게시글넘버
-  const postIdx = params.idx;
+  const postIdx = params.idx?.slice(1,);   //게시글넘버
   const [searchParams] = useSearchParams();
-  //댓글넘버 from qs
-  const commentIdx = searchParams.get('reply');
-  //선택옵션 전역상태관리
-  const [selectedOpt, setSelectedOpt] = useRecoilState(ReportSelectOptionAtom);
-  //신고텍스트
-  const [reportText, setReportText] = useState('');
+  const commentIdx = searchParams?.get('reply');   //댓글넘버 from 쿼리스트링
+  const [selectedOpt, setSelectedOpt] = useRecoilState(ReportSelectOptionAtom); 
+  const [reportText, setReportText] = useState('');  //신고텍스트
   const navigate = useNavigate();
 
-  useEffect(() => {
+  useEffect(() => { //언마운트시 선택옵션 초기화
     window.scrollTo(0, 0);
     return () => {
       setSelectedOpt(null);
     };
-  }, [setSelectedOpt]);
+  }, []);
 
   const declarationTypeArray = ['PRIVATE', 'PURPOSE', 'THREATS', 'SEXUALLY', 'RELIGION', 'SUSPECTED', 'COMMERCIAL', 'POLITICAL', 'ETC'];
 
@@ -47,26 +43,25 @@ export default function ReportModal() {
     '과도한 정치적 견해 표출',
     '기타',
   ];
-
-    const { mutate } = usePostReport({
-    userId: userId ? userId : 'error', //userId
-    postIdx: !postIdx ? null : Number.parseInt(postIdx),
-    commentIdx: !commentIdx ? null : Number.parseInt(commentIdx),
-    declarationType: selectedOpt !== null ? declarationTypeArray[selectedOpt] : null,
-    content: reportText,
-  });
-  useEffect(() => {
+    useEffect(() => {
     const fetchUserId = async () => {
       try {
         const fetchedUserId = await HttpClient.get('/api/profiles/me');
-        setUserId(fetchedUserId.id);
+        setUserId(fetchedUserId.nickname);
       } catch (e) {
         console.error(e,'userId를 받아오지 못했습니다.');
       }
     };
     fetchUserId()
   },[])
-  console.log(userId)
+    const { mutate:postReportMutate } = usePostReport({
+    userId: userId ? userId : 'error', //userId
+    postIdx: !postIdx ? null : Number.parseInt(postIdx),
+    commentIdx: !commentIdx ? null : Number.parseInt(commentIdx),
+    declarationType: selectedOpt !== null ? declarationTypeArray[selectedOpt] : null,
+    content: reportText,
+  });
+
   return (
     <div
       css={{
@@ -173,7 +168,7 @@ export default function ReportModal() {
                 }
                 // 옵션있고 텍스트 20자 이상인 경우
                 if (selectedOpt && reportText.length >= 20) {
-                  mutate();
+                  postReportMutate();
                 }
               }}
             >

--- a/src/components/MatchPost/ReportModal/index.tsx
+++ b/src/components/MatchPost/ReportModal/index.tsx
@@ -59,7 +59,7 @@ export default function ReportModal() {
     const fetchUserId = async () => {
       try {
         const fetchedUserId = await HttpClient.get('/api/profiles/me');
-        setUserId(fetchedUserId);
+        setUserId(fetchedUserId.id);
       } catch (e) {
         console.error(e,'userId를 받아오지 못했습니다.');
       }

--- a/src/components/Matching/SearchBar/index.tsx
+++ b/src/components/Matching/SearchBar/index.tsx
@@ -6,7 +6,21 @@ import React, { useState, useRef ,useEffect } from 'react';
 import SearchIcon from '../../../images/components/Matching/searchIcon.svg';
 import { useSetRecoilState } from 'recoil';
 import { MatchingControllerState } from '../../../recoil/atom/MatchingControllerState';
+import HttpClient from '../../../services/HttpClient';
+
 const CustomSearchBar = () => {
+  let [userId,setUserId] = useState<string>('');
+  useEffect(() => {
+    const fetchUserId = async () => {
+      try {
+        const fetchedUserId = await HttpClient.get('/api/profiles/me');
+        setUserId(fetchedUserId.id);
+      } catch (e) {
+        console.error(e,'userId를 받아오지 못했습니다.');
+      }
+    };
+    fetchUserId()
+  },[userId])
   const inputRef = useRef<HTMLInputElement>(null);
   const [inputValue, setInputValue] = useState('');
   const [placeHolderState, setPlaceHolderState] = useState(true);
@@ -25,9 +39,10 @@ const CustomSearchBar = () => {
         font-size: 22px;
         font-weight: 500px;
         position: relative;
-        right: 6rem;
+        right: 2rem;
         bottom: 5.45rem;
         height: 0;
+        left: auto;
       `}
     >
       <span
@@ -41,7 +56,7 @@ const CustomSearchBar = () => {
             font-weight: 700;
           `}
         >
-          히순이
+          {userId ? userId : '익명'}
         </span>
         님 👋
       </span>

--- a/src/components/Matching/SearchBar/index.tsx
+++ b/src/components/Matching/SearchBar/index.tsx
@@ -14,7 +14,7 @@ const CustomSearchBar = () => {
     const fetchUserId = async () => {
       try {
         const fetchedUserId = await HttpClient.get('/api/profiles/me');
-        setUserId(fetchedUserId.id);
+        setUserId(fetchedUserId.nickname);
       } catch (e) {
         console.error(e,'userId를 받아오지 못했습니다.');
       }

--- a/src/hooks/MatchingPost/usePostReport.ts
+++ b/src/hooks/MatchingPost/usePostReport.ts
@@ -12,27 +12,23 @@ export interface IReportBody {
 }
 
 //게시글 및 댓글 신고 요청 훅
-export const usePostReport = (body: IReportBody) => {
+export const usePostReport = (body:IReportBody) => {
   const queryClient = useQueryClient();
-  const matchingArticleLikeMutationFn = async () => {
-    try {
-      const path = `/declaration/report`;
-      const res = HttpClient.post(path, body,{
-        'Content-Type': 'application/json',
-      });
-      return res;
-    } catch (e) {
-      console.error(`게시글 및 유저 신고에 실패했습니다. error : ${(e as AxiosError).message}`);
-    }
-  };
+  const postReportMutationFn = async ()  => {
+    const path = `/declaration/report`; 
+    const res = await HttpClient.post(path,body ,{
+      'Content-Type': 'application/json',
+    });
+    return res.data;
+};
   const navigate = useNavigate();
-  return useMutation<IReportBody, AxiosError>(() => matchingArticleLikeMutationFn(), {
+  return useMutation<IReportBody, AxiosError>( postReportMutationFn, {
     onSuccess: () => {
       if (body.commentIdx) alert('댓글에 대한 신고가 정상적으로 접수되었습니다.');
       else {
         alert('게시글에 대한 신고가 정상적으로 접수되었습니다.');
       }
-      navigate(`/matchPost/${body.postIdx}`)
+      navigate(`/matching`)
       queryClient.invalidateQueries(['post-info']);
     },
     onError: e => {

--- a/src/hooks/MatchingPost/usePostReport.ts
+++ b/src/hooks/MatchingPost/usePostReport.ts
@@ -1,11 +1,10 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import HttpClient from '../../services/HttpClient';
-import { AxiosError } from 'axios';
+import { AxiosError} from 'axios';
 import { useNavigate } from 'react-router-dom';
 
 export interface IReportBody {
   userId: string;
-  reportId: string;
   postIdx: number | null;
   commentIdx: number | null;
   declarationType: string | null;

--- a/src/pages/MatchPost/index.tsx
+++ b/src/pages/MatchPost/index.tsx
@@ -69,7 +69,7 @@ export default function MatchingPostPage() {
   };
   const { data, isError, error, isLoading, isFetching, status } = useQuery<IMatchingPostPage, AxiosError>(['post-info'], getPostInfoFn, {
     staleTime: 1000,
-    retry: 3,
+    retry: 1,
     retryDelay: 2000,
   },);
 

--- a/src/pages/Posting/PutPosting/index.tsx
+++ b/src/pages/Posting/PutPosting/index.tsx
@@ -18,6 +18,8 @@ import { IImage } from "../../../interfaces/IImage";
 import { IGetPosting, IPosting } from "../../../interfaces/Posting/IPosting";
 import PostingAPI from "../../../api/PostingAPI";
 import calendarCloseBtn from "../../../images/components/Posting/calendarCloseBtn.svg";
+import HttpClient from "../../../services/HttpClient";
+import { AxiosError,AxiosResponse} from "axios";
 
 const activityData_Imoji = [
   "맛집 가기😋", "카페 가기☕", "전시만 보기👓", "만나서 정해요!"
@@ -37,11 +39,30 @@ interface IExhibition {
 };
 const OPENCHAT_GUIDELINK = "https://cs.kakao.com/helps_html/1073184404?locale=ko";
 
-const PutPosting = () => {
+const PutPosting = () => { 
   const isMobile = useIsMobile();
   const navigate = useNavigate();
   const { idx } = useParams();
-
+  useEffect(()=>{
+    const isWriterCorrect = async ()=>{
+      try{
+        const { postIdx } = useParams();
+        const {writerIdx} = await HttpClient.get(`/post/${postIdx}`) //
+        const {id : userIdx} = await  HttpClient.get('/api/members/me')
+        console.log('test',userIdx,writerIdx)
+        if( userIdx !== writerIdx ){
+          //만약 해당 게시글의 작성자idx와 본인의Idx가 일치하지않는다면
+          navigate('/matching')
+        }
+      } catch(e){
+        // 에러발생시
+        console.log('과연 두번 이펙트가 발생?')
+        navigate('/matching')
+        console.error(`${(e as AxiosError)}: userIdx를 불러올 수 없습니다`)
+      }
+    }
+    isWriterCorrect()
+  },[idx])
   const [title, setTitle] = useState<string>("");
   const onChangeTitle = (e: ChangeEvent<HTMLInputElement>) => {
     if(e.target.value.length >= 31) {
@@ -323,7 +344,6 @@ const PutPosting = () => {
         console.error({e});
       })
   }, []);
-
 
 
   const onClickSubmitBtn = () => {

--- a/src/pages/Posting/PutPosting/index.tsx
+++ b/src/pages/Posting/PutPosting/index.tsx
@@ -42,21 +42,19 @@ const OPENCHAT_GUIDELINK = "https://cs.kakao.com/helps_html/1073184404?locale=ko
 const PutPosting = () => { 
   const isMobile = useIsMobile();
   const navigate = useNavigate();
-  const { idx } = useParams();
+  const [idx,setIdx] = useState(()=>useParams().idx)
   useEffect(()=>{
     const isWriterCorrect = async ()=>{
       try{
-        const { postIdx } = useParams();
-        const {writerIdx} = await HttpClient.get(`/post/${postIdx}`) //
-        const {id : userIdx} = await  HttpClient.get('/api/members/me')
-        console.log('test',userIdx,writerIdx)
+        const [res1,res2]= await Promise.all([HttpClient.get(`/post/${idx}`),HttpClient.get('/api/members/me')])
+        const writerIdx = res1.writerIdx; // idx번게시글의 작성자IDX
+        const userIdx = res2.id // 사용자 고유ID
         if( userIdx !== writerIdx ){
           //만약 해당 게시글의 작성자idx와 본인의Idx가 일치하지않는다면
           navigate('/matching')
         }
       } catch(e){
         // 에러발생시
-        console.log('과연 두번 이펙트가 발생?')
         navigate('/matching')
         console.error(`${(e as AxiosError)}: userIdx를 불러올 수 없습니다`)
       }
@@ -404,7 +402,6 @@ const PutPosting = () => {
       }
       // 이미지 등록
 
-       
       alert("게시글이 등록되었습니다.");
       // navigate(-1);
     }


### PR DESCRIPTION
## 작업 내용
>1)신고하기 에러 해결 
2)매칭 메인페이지 서치바에 유저 닉네임 추가
3)게시글 수정하기 페이지 에러 해결 

<br/>

## 변동 내용
> 1)신고하기 페이지에서 post하는 body값에 에러가 있었습니다.
3)put-posting 게시글 수정하기 페이지에서  나의 게시글 번호가 아닌 타인의 게시글 번호를 주소창으로 입력시 이동 및 수정 가능한 버그를 방지하기를 위해 로직 추가했습니다. (아래 첨부 자료 확인)


<br/>

## 자료 첨부
> useEffect(()=>{
    const isWriterCorrect = async ()=>{
      try{
        const [res1,res2]= await Promise.all([HttpClient.get(`/post/${idx}`),HttpClient.get('/api/members/me')])
        const writerIdx = res1.writerIdx; // idx번게시글의 작성자IDX
        const userIdx = res2.id // 사용자 고유ID
        if( userIdx !== writerIdx ){
          //만약 해당 게시글의 작성자idx와 본인의Idx가 일치하지않는다면
          navigate('/matching')
        }
      } catch(e){
        // 에러발생시
        navigate('/matching')
        console.error(`${(e as AxiosError)}: userIdx를 불러올 수 없습니다`)
      }
    }
    isWriterCorrect()
  },[idx])
1. 주소창에서 파싱한 게시글 넘버에 해당하는 정보를 받아오는 API요청 
2. 현재 로그인한 유저 idx와 게시글 작성자 idx 비교  (  userIdx !== writerIdx )
3. 일치하지 않으면 /matching으로 redirect 
<br/>

## 중점으로 리뷰받고 싶은 내용
> X
<br/>

## 참고자료
>X
