### PR TITLE
QA: 유저이미지 렌더 및 게시글 상태변경 API 수정

### DIFF
--- a/src/components/MatchPost/PostLabel/index.tsx
+++ b/src/components/MatchPost/PostLabel/index.tsx
@@ -10,7 +10,6 @@ import PostStateModal from '../PostStateModal';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { PostStateModalSwitch } from '../../../recoil/atom/PostStateModalSwitch';
 import { useUpdateMatchingStatusCancel } from '../../../hooks/MatchingPost/useUpdateMatchingStatusCancle';
-import useLoginInfo from '../../../hooks/useLoginInfo';
 import { userIdxState } from '../../../recoil/atom/LoginInfoState';
 
 export default function MatchPostLabel({ data, postIDX }: { data?: IMatchingPostPage; postIDX: string | undefined }) {
@@ -19,8 +18,8 @@ export default function MatchPostLabel({ data, postIDX }: { data?: IMatchingPost
   //게시글 status drop down메뉴
   const [isStatusModalOpen, setIsStatusModalOpen] = useState<boolean>(false);
   //게시글 모집취소 mutation hook
+
   const { mutate: cancelMutate } = useUpdateMatchingStatusCancel(postIDX);
-  const loginInfo = useLoginInfo();
   let userIdx: number | null = useRecoilValue(userIdxState);
 
   return (
@@ -99,6 +98,7 @@ export default function MatchPostLabel({ data, postIDX }: { data?: IMatchingPost
                       if (!isPostStateModalOpen) {
                         setIsPostStateModalOpen(true);
                       }
+
                       setIsStatusModalOpen(false);
                       break;
                     case 'C':
@@ -134,7 +134,7 @@ export default function MatchPostLabel({ data, postIDX }: { data?: IMatchingPost
                       const confirm = window.confirm(`게시글 모집을 취소하시겠습니까? 모집 취소시 게시글 리스트에서 해당 게시글이 사라집니다.`);
                       if (confirm) {
                         setIsStatusModalOpen(false);
-                        //게시글모집취소 mutate
+                        // 게시글모집취소 mutate
                         cancelMutate(postIDX);
                       }
                       setIsStatusModalOpen(false);

--- a/src/components/MatchPost/PostReplySection/index.tsx
+++ b/src/components/MatchPost/PostReplySection/index.tsx
@@ -271,7 +271,8 @@ export const OriginalReplyComponent = ({ reply }: { reply: IComments }) => {
         navigate(`/others/:${reply?.writerIdx}`)
         window.scrollTo(0, 0)
         }}>
-          <ImageBox width={32} height={32} source={(reply.writerImg = userDefaultImage)} />
+          <ImageBox width={32} height={32} source={reply.writerImg}
+          />
         </div>
           <div css={{ display: 'flex', flex: '0 1 auto' }}>
             <div css={{ borderRight: `1px solid ${COLORS.Gray2}`, padding: '0 12px', fontSize: 20, color: COLORS.Gray3, fontWeight: 800 }}>
@@ -745,7 +746,7 @@ export const SecondaryReplyComponent = ({
             navigate(`/others/:${reReply?.writerIdx}`)
             window.scrollTo(0, 0)
             }}>
-            <ImageBox width={32} height={32} source={(reReply.writerImg = userDefaultImage)} />
+            <ImageBox width={32} height={32} source={reReply.writerImg} />
           </div>
           <div css={{ display: 'flex', flex: '0 1 auto' }}>
             <div css={{ borderRight: `1px solid ${COLORS.Gray2}`, padding: '0 12px', fontSize: 20, color: COLORS.Gray3, fontWeight: 800 }}>

--- a/src/components/MatchPost/PostReplySection/index.tsx
+++ b/src/components/MatchPost/PostReplySection/index.tsx
@@ -552,8 +552,12 @@ export const SecondaryReplyInputComponent = ({
         onClick={e => {
           e.stopPropagation();
           if (userLoginInfo?.isLoggedIn === true) {
-            setIsDaetgulOpen(false);
-            mutate({ replyIDX, userIDX, body: { content: secondaryReplyText } });
+            if(secondaryReplyText.trim().length !== 0){
+              setIsDaetgulOpen(false);
+              mutate({ replyIDX, userIDX, body: { content: secondaryReplyText } });
+            } else{ 
+              alert('댓글 내용을 입력해 주세요.')
+            } 
           } else {
             alert('로그인이 필요합니다');
           }

--- a/src/components/MatchPost/PostReplySection/index.tsx
+++ b/src/components/MatchPost/PostReplySection/index.tsx
@@ -94,17 +94,14 @@ export default function ReplySectionComponent({ postIDX }: { postIDX?: string })
 export const InputReplyWrapper = ({ postIDX, userLoginInfo }: { postIDX?: string; userLoginInfo?: ILoginInfo }) => {
   let [userImg,setUserImg] = useState<string>('')
   useEffect(()=>{
-    try{
       (async function getUserImg (){
-      const res = await HttpClient.get('api/profiles/me')
-      setUserImg(res.mainImg)
+        try{
+          const res = await HttpClient.get('api/profiles/me')
+          setUserImg(res.mainImg)}
+        catch(e){
+          console.error(`댓글입력창의 이미지를 불러올 수 없습니다.${(e as AxiosError)}`)
+        }
       })()
-    }   
-    catch(e){
-      console.error(`댓글입력창의 이미지를 불러올 수 없습니다.${(e as AxiosError)}`)
-      setUserImg(userDefaultImage)
-    }
-    
   },[])
   const [textState, setTextState] = useState('');
   const textRef = useRef<HTMLTextAreaElement>(null);

--- a/src/components/MatchPost/PostReplySection/index.tsx
+++ b/src/components/MatchPost/PostReplySection/index.tsx
@@ -92,6 +92,20 @@ export default function ReplySectionComponent({ postIDX }: { postIDX?: string })
 }
 //댓글입력창
 export const InputReplyWrapper = ({ postIDX, userLoginInfo }: { postIDX?: string; userLoginInfo?: ILoginInfo }) => {
+  let [userImg,setUserImg] = useState<string>('')
+  useEffect(()=>{
+    try{
+      (async function getUserImg (){
+      const res = await HttpClient.get('api/profiles/me')
+      setUserImg(res.mainImg)
+      })()
+    }   
+    catch(e){
+      console.error(`댓글입력창의 이미지를 불러올 수 없습니다.${(e as AxiosError)}`)
+      setUserImg(userDefaultImage)
+    }
+    
+  },[])
   const [textState, setTextState] = useState('');
   const textRef = useRef<HTMLTextAreaElement>(null);
   //댓글입력api
@@ -131,7 +145,7 @@ export const InputReplyWrapper = ({ postIDX, userLoginInfo }: { postIDX?: string
         navigate(`/others/:${userLoginInfo?.userIdx}`)
         window.scrollTo(0,0)
       }}>
-        <ImageBox width={32} height={32} source={userDefaultImage} />
+        <ImageBox width={32} height={32} source={userImg ? userImg : userDefaultImage} />
       </div>
       <textarea
         onChange={e => {

--- a/src/components/MatchPost/PostStateModal/index.tsx
+++ b/src/components/MatchPost/PostStateModal/index.tsx
@@ -8,14 +8,13 @@ import NoCheck from '../../../images/components/MatchPost/InviteModal/NoCheck.sv
 import OnCheck from '../../../images/components/MatchPost/InviteModal/OnCheck.svg';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { hoverAnimation } from '../PostArticle/styles';
-// import { useUpdateMatchingStatus } from '../../../hooks/MatchingPost/useUpdateStateAndPostUserList';
 import { IInvitationProps } from '../../../hooks/MatchingPost/useGetInviteModalList';
 import { PostStateModalSwitch } from '../../../recoil/atom/PostStateModalSwitch';
 import { PostCompleteUserList } from '../../../recoil/atom/PostCompleteUserList';
 import HttpClient from '../../../services/HttpClient';
 import { AxiosError } from 'axios';
 import { useQuery } from '@tanstack/react-query';
-import { useUpdateStateAndPostUserList } from '../../../hooks/MatchingPost/useUpdateStateAndPostUserList';
+import { useUpdateCombo } from '../../../hooks/MatchingPost/useUpdateCombo';
 //게시글 모집완료(complete)시 등장모달
 const PostStateModal = ({ postIDX }: { postIDX: string | undefined }) => {
   const [modalIsOpen, setModalIsOpen] = useRecoilState(PostStateModalSwitch);
@@ -57,14 +56,6 @@ const PostStateModal = ({ postIDX }: { postIDX: string | undefined }) => {
     },
   };
 
-  // //컴포넌트 언마운트시 모달 클리어
-  // useEffect(() => {
-  //   return () => {
-  //     setModalIsOpen(false);
-  //   };
-  // }, [setModalIsOpen]);
-
-  //초대수락 인원(함께한 인원) 리스트 Query
   const companyListQueryFn = async () => {
     try {
       const res = await HttpClient.get(`/matching/${postIDX}/oklist`);
@@ -76,8 +67,8 @@ const PostStateModal = ({ postIDX }: { postIDX: string | undefined }) => {
   };
   const { data: companionList } = useQuery<IInvitationProps[]>(['company-list'], companyListQueryFn);
 
-  // 게시글 상태변경 커스텀훅 (complete)
-  const { mutate: updateMutate } = useUpdateStateAndPostUserList(postIDX, userList);
+  // 함께한 유저리스트 전송 & 게시글 상태 완료  
+  const { mutate: updateMutate } = useUpdateCombo(postIDX, userList);
   
   return (
     <div>
@@ -141,7 +132,11 @@ const PostStateModal = ({ postIDX }: { postIDX: string | undefined }) => {
               setModalIsOpen(false);
               if (confirmed === true) {
                 //게시글 상태 업데이트 put => userList 발송
-                updateMutate(postIDX);
+                if(userList.length ===0) {
+                  alert('함께 간 유저를 선택해주세요')
+                } else {
+                  updateMutate(postIDX);
+                }
               }
             }}
             css={{

--- a/src/hooks/MatchingPost/useUpdateCombo.ts
+++ b/src/hooks/MatchingPost/useUpdateCombo.ts
@@ -1,36 +1,23 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import HttpClient from '../../services/HttpClient';
 import { AxiosError } from 'axios';
-//게시글 모집상태 변경 hook (complete) => 성공시 함께간인원 발송
-//(게시글작성자인 경우에만 가능하도록 제한 필요)
-export const useUpdateStateAndPostUserList = (postIDX: string | undefined, userList: [] | number[]) => {
+//같이같 유저 리스트 성공적으로 발송시 게시글 모집상태 완료로 변경 
+export const useUpdateCombo = (postIDX: string | undefined, userList: [] | number[]) => {
   const queryClient = useQueryClient();
   //complete상태변경 mutateFn
   const postStatusMutationFn = async (postIDX: string | undefined) => {
-    try {
       const path = `/post/${postIDX}/complete`;
-      const res = HttpClient.put(path, postIDX, {
-        'Content-Type': 'application/json',
-      });
+      const res = HttpClient.put(path, postIDX);
       return res;
-    } catch (e) {
-      console.error(`${postIDX}번 게시글의 모집상태 변경에 실패했습니다. error : ${(e as AxiosError).message}`);
-      return;
-    }
   };
   //함께간인원 유저리스트 송 mutateFn
   const postCompleteUserListMutationFn = async () => {
-    try {
       const path = `/matching/${postIDX}/oksave`;
       const res = HttpClient.put(path, userList, {
         'Content-Type': 'application/json',
       });
       return res;
-    } catch (e) {
-      console.error(`함께한 유저 리스트 발송 실패. error : ${(e as AxiosError).message}`);
-      return;
     }
-  };
 
   //2nd step
   const { mutate: userListPostMutation } = useMutation(postCompleteUserListMutationFn, {
@@ -50,8 +37,8 @@ export const useUpdateStateAndPostUserList = (postIDX: string | undefined, userL
       userListPostMutation();
       queryClient.invalidateQueries(['post-info']);
     },
-    onError: e => {
-      console.error(`${postIDX}번 게시글의 모집상태 변경에 실패했습니다. error : ${(e as AxiosError).message}`);
+    onError: (e:AxiosError) => {
+      console.error(`${postIDX}번 게시글의 모집상태 변경에 실패했습니다. error : ${e.message}`);
       return;
     },
   });

--- a/src/hooks/MatchingPost/useUpdateMatchingStatusCancle.ts
+++ b/src/hooks/MatchingPost/useUpdateMatchingStatusCancle.ts
@@ -1,32 +1,27 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import HttpClient from '../../services/HttpClient';
 import { AxiosError } from 'axios';
-import { useNavigate } from 'react-router-dom';
 
 //게시글 모집상태 변경 hook (cancel:모집취소)
 //(게시글작성자인 경우에만 가능하도록 제한 필요)
 export const useUpdateMatchingStatusCancel = (postIDX: string | undefined) => {
-  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const postStatusMutationFn = async (postIDX: string | undefined) => {
-    try {
       const path = `/post/${postIDX}/cancel`;
-      const res = HttpClient.put(path, postIDX);
-      return res;
-    } catch (e) {
-      console.error(`${postIDX}번 게시글의 모집취소에 실패했습니다. error : ${(e as AxiosError).message}`);
-      return;
-    }
+      HttpClient.put(path, postIDX);
+      // return res;
+    //  catch (e) {
+      // console.error(`${postIDX}번 게시글의 모집취소에 실패했습니다. error : ${(e as AxiosError).message}`);
+      // return;
+    // }
   };
   return useMutation(postStatusMutationFn, {
     onSuccess: () => {
-      queryClient.invalidateQueries(['post-info']);
-      navigate('/matching', { replace: true });
+      // queryClient.invalidateQueries(['post-info']);
       window.alert(`게시글의 상태가 모집취소로 변경되었습니다.`)
     },
     onError: e => {
       console.error(`${postIDX}번 게시글의 모집취소에 실패했습니다. error : ${(e as AxiosError).message}`);
-      return;
     },
   });
 };


### PR DESCRIPTION
## 작업 내용
1. 게시글 내부페이지 유저 이미지 렌더되도록 비동기처리 추가
2. 게시글 상태변경(완료,취소) 코드 일부 리팩토링 


<br/>

## 변동 내용
X

<br/>

## 자료 첨부
X
<br/>

## 중점으로 리뷰받고 싶은 내용
X

<br/>

## 참고자료
X
