### PR TITLE
Feat/auth: OAUTH 토큰 유효성 검사 로직 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "dayjs": "^1.11.10",
         "framer-motion": "^10.10.0",
         "fslightbox-react": "^1.7.6",
+        "jwt-decode": "^4.0.0",
         "lottie-react": "^2.4.0",
         "react": "^18.2.0",
         "react-calendar": "^4.4.0",
@@ -12061,6 +12062,14 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/kind-of": {
@@ -26645,6 +26654,11 @@
         "array-includes": "^3.1.5",
         "object.assign": "^4.1.3"
       }
+    },
+    "jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA=="
     },
     "kind-of": {
       "version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "dayjs": "^1.11.10",
     "framer-motion": "^10.10.0",
     "fslightbox-react": "^1.7.6",
+    "jwt-decode": "^4.0.0",
     "lottie-react": "^2.4.0",
     "react": "^18.2.0",
     "react-calendar": "^4.4.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ import OtherProfile from './pages/OtherProfile';
 import PostPosting from './pages/Posting/PostPosting';
 import 'react-day-picker/dist/style.css';
 import GoogleRedirectHandler from './components/Login/GoogleRedirectHandler';
-import { Suspense, useEffect } from 'react';
+import { Suspense, useEffect, useState } from 'react';
 import HttpClient, { axiosInstance } from './services/HttpClient';
 import NotFound from './pages/NotFound';
 import ReportModal from './components/MatchPost/ReportModal';
@@ -24,78 +24,71 @@ import useIsMobile from './hooks/useIsMobile';
 import MobileLanding from './pages/MobileLanding';
 import { useSetRecoilState } from 'recoil';
 import { profileRegisteredState, userIdxState } from './recoil/atom/LoginInfoState';
-import axios, { AxiosError } from 'axios';
+import { AxiosError } from 'axios';
 import { jwtDecode, JwtPayload } from 'jwt-decode';
+import { isLoginAtom } from './recoil/atom/isLoginAtom';
 
 function App() {
   const queryClient = new QueryClient();
-  // const accessToken: string | null = localStorage.getItem('accessToken');
-  //atom setter
+
   const setIsProfileRegistered = useSetRecoilState(profileRegisteredState);
   const setUserIdx = useSetRecoilState(userIdxState);
 
-  useEffect(()=>{
-    // 초기 1회 토큰 세팅 refresh가 있다면 새로운 access 토큰으로 갱신 (인가처리)
-    // refresh가 정상으로 존재한다면?
-    const accessToken: string | null = localStorage.getItem('accessToken');
-    if(accessToken){
-      // HttpClient.post(`/api/auth/token/access`)
-      axiosInstance.post(`/api/auth/token/access`)
-      .then(res => {
-        const token = res?.data?.accessToken;
-        if(!!token){
-          axiosInstance.defaults.headers.common['Authorization'] = `Bearer ${token}`;
-          localStorage.setItem('accessToken', `${token}`);
-        }
-      })
-      .catch((error: AxiosError) => {
-        if(error?.response?.status === 401){
-          //유효하지않는 문자열 && 토큰 만료는 401에러고, 
-          console.error(error.message)
-          localStorage.removeItem('accessToken');
-          alert('유효하지 않은 토큰입니다. 다시 로그인 해주세요')
-          return
-        }
-        else if(error?.response?.status === 404){
-          //본인의 리프레시 토큰이 아닌 경우 404 
-          console.error(error.message)
-          localStorage.removeItem('accessToken');
-          alert('유효하지 않은 토큰입니다. 다시 로그인 해주세요')
-          return
-        }
-        return;
-      });
-    }
-  },[])
+  const setIsLoginAtom = useSetRecoilState(isLoginAtom);
+  const [trigger, setTrigger] = useState(false);
 
+  const refreshToken = () => {
+    const accessToken: string | null = localStorage.getItem('accessToken');
+    if (accessToken) {
+      setIsLoginAtom(true);
+      axiosInstance
+        .post(`/api/auth/token/access`)
+        .then(res => {
+          const token = res?.data?.accessToken;
+          if (!!token) {
+            axiosInstance.defaults.headers.common['Authorization'] = `Bearer ${token}`;
+            localStorage.setItem('accessToken', `${token}`);
+          }
+        })
+        .catch((error: AxiosError) => {
+          if (error?.response?.status === 401 || error?.response?.status === 404) {
+            //유효하지않은 문자열 && 토큰 만료 401
+            //본인의 토큰이 아닌 경우 404
+            localStorage.removeItem('accessToken');
+            setIsLoginAtom(false);
+            alert('유효하지 않은 토큰입니다. 다시 로그인 해주세요');
+            return;
+          }
+          return;
+        });
+    }
+  };
+
+  // 1. 유효성 검증 통과시 access token 갱신
   useEffect(() => {
-    // const accessToken: string | null = localStorage.getItem('accessToken')
+    refreshToken();
+  }, [trigger]);
+
+  // 2. interceptor 유효성 검사 
+  useEffect(() => {
+    const accessToken: string | null = localStorage.getItem('accessToken');
     axiosInstance.interceptors.request.use(
       async config => {
-        // if (accessToken) {
-          try {
-            // 디코딩
-            const accessToken: string | null = localStorage.getItem('accessToken')
-            if (accessToken) {
-              const decodedToken = jwtDecode<JwtPayload>(accessToken);
-              const currentTime = Date.now() / 1000; // ms -> seconds
-              // 유효성 검증 ( 만료 5분 전을 초과했다면 access 갱신 )
-              if (decodedToken.exp && decodedToken.exp < currentTime + 300) {
-                //유효한 refesh토큰이 헤더에 있다면 정상 동작
-                const res = await axiosInstance.post('/api/auth/token/access'); 
-                const token = res?.data?.accessToken;
-                if(token){
-                  config.headers.common['Authorization'] = `Bearer ${token}`; // 갱신된 값으로 설정
-                  localStorage.setItem('accessToken', `${token}`); // 로컬스토리지 값도 갱신
-                }
-              }
+        try {
+          // decode token
+          if (accessToken) {
+            const decodedToken = jwtDecode<JwtPayload>(accessToken);
+            const currentTime = Date.now() / 1000;
+            // 유효성 검증 ( 만료 5분 전을 초과했다면 access 갱신 )
+            if (decodedToken.exp && decodedToken.exp < currentTime + 300) {
+              setTrigger(!trigger);
             }
-          } catch (error) {
-            localStorage.removeItem('accessToken'); // refresh 토큰 만료시 로컬스토리지 accessToken 삭제
-            alert('토큰이 만료되었습니다. 다시 로그인 해주세요.');
-            throw error;
           }
-        // }
+        } catch (error) {
+          localStorage.removeItem('accessToken'); // refresh 토큰 만료시 로컬스토리지 accessToken 삭제
+          alert('유효하지 않은 토큰입니다. 다시 로그인 해주세요');
+          throw error;
+        }
         return config;
       },
       (error: AxiosError) => {
@@ -105,19 +98,19 @@ function App() {
   }, []);
 
   useEffect(() => {
-    const accessToken: string | null = localStorage.getItem('accessToken')
-    if(accessToken){
+    const accessToken: string | null = localStorage.getItem('accessToken');
+    if (accessToken) {
       HttpClient.get('/api/members/find')
-      .then(res => {
-        const userIdx: number | null = res.idx;
-        const profileRegistered: boolean = res.isprofile;
-        setUserIdx(userIdx); 
-        setIsProfileRegistered(profileRegistered); 
-      })
-      .catch((error: AxiosError) => {
-        console.error(error.message);
-        return
-      });
+        .then(res => {
+          const userIdx: number | null = res.idx;
+          const profileRegistered: boolean = res.isprofile;
+          setUserIdx(userIdx);
+          setIsProfileRegistered(profileRegistered);
+        })
+        .catch((error: AxiosError) => {
+          console.error(error.message);
+          return;
+        });
     }
   }, []);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,6 @@ import { useSetRecoilState } from 'recoil';
 import { profileRegisteredState, userIdxState } from './recoil/atom/LoginInfoState';
 import { AxiosError } from 'axios';
 import { jwtDecode, JwtPayload } from 'jwt-decode';
-import { isLoginAtom } from './recoil/atom/isLoginAtom';
 
 function App() {
   const queryClient = new QueryClient();
@@ -34,18 +33,16 @@ function App() {
   const setIsProfileRegistered = useSetRecoilState(profileRegisteredState);
   const setUserIdx = useSetRecoilState(userIdxState);
 
-  const setIsLoginAtom = useSetRecoilState(isLoginAtom);
   const [trigger, setTrigger] = useState(false);
 
   const refreshToken = () => {
     const accessToken: string | null = localStorage.getItem('accessToken');
     if (accessToken) {
-      setIsLoginAtom(true);
       axiosInstance
         .post(`/api/auth/token/access`)
         .then(res => {
           const token = res?.data?.accessToken;
-          if (!!token) {
+          if (token) {
             axiosInstance.defaults.headers.common['Authorization'] = `Bearer ${token}`;
             localStorage.setItem('accessToken', `${token}`);
           }
@@ -55,7 +52,6 @@ function App() {
             //유효하지않은 문자열 && 토큰 만료 401
             //본인의 토큰이 아닌 경우 404
             localStorage.removeItem('accessToken');
-            setIsLoginAtom(false);
             alert('유효하지 않은 토큰입니다. 다시 로그인 해주세요');
             return;
           }
@@ -66,7 +62,7 @@ function App() {
 
   // 1. 유효성 검증 통과시 access token 갱신
   useEffect(() => {
-    refreshToken();
+    refreshToken() 
   }, [trigger]);
 
   // 2. interceptor 유효성 검사 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,87 +1,146 @@
-import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
-import MainPage from "./pages/Main";
-import styled from "@emotion/styled";
-import { Global } from "@emotion/react";
-import globalStyles from "./fonts/GlobalStyles";
-import KaKao from "./pages/KaKao";
-import PostMyProfile from "./pages/MyProfile/PostMyProfile";
-import MatchingPage from "./pages/Matching";
+import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
+import MainPage from './pages/Main';
+import styled from '@emotion/styled';
+import { Global } from '@emotion/react';
+import globalStyles from './fonts/GlobalStyles';
+import KaKao from './pages/KaKao';
+import PostMyProfile from './pages/MyProfile/PostMyProfile';
+import MatchingPage from './pages/Matching';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
-import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
-import MatchingPostPage from "./pages/MatchPost";
-import OtherProfile from "./pages/OtherProfile";
-import PostPosting from "./pages/Posting/PostPosting";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import MatchingPostPage from './pages/MatchPost';
+import OtherProfile from './pages/OtherProfile';
+import PostPosting from './pages/Posting/PostPosting';
 import 'react-day-picker/dist/style.css';
-import GoogleRedirectHandler from "./components/Login/GoogleRedirectHandler";
-import { Suspense, useEffect } from "react";
-import { axiosInstance } from "./services/HttpClient";
-import NotFound from "./pages/NotFound";
+import GoogleRedirectHandler from './components/Login/GoogleRedirectHandler';
+import { Suspense, useEffect } from 'react';
+import HttpClient, { axiosInstance } from './services/HttpClient';
+import NotFound from './pages/NotFound';
 import ReportModal from './components/MatchPost/ReportModal';
-import PutMyProfile from "./pages/MyProfile/PutMyProfile";
-import PutPosting from "./pages/Posting/PutPosting";
-import useLoginInfo from "./hooks/useLoginInfo";
-import LottiePageRouting from "./components/LottieFiles/LottiePageRouting";
-import useIsMobile from "./hooks/useIsMobile";
-import MobileLanding from "./pages/MobileLanding";
-import { useSetRecoilState } from "recoil";
-import { profileRegisteredState, userIdxState } from "./recoil/atom/LoginInfoState";
-import axios from "axios";
+import PutMyProfile from './pages/MyProfile/PutMyProfile';
+import PutPosting from './pages/Posting/PutPosting';
+import LottiePageRouting from './components/LottieFiles/LottiePageRouting';
+import useIsMobile from './hooks/useIsMobile';
+import MobileLanding from './pages/MobileLanding';
+import { useSetRecoilState } from 'recoil';
+import { profileRegisteredState, userIdxState } from './recoil/atom/LoginInfoState';
+import axios, { AxiosError } from 'axios';
+import { jwtDecode, JwtPayload } from 'jwt-decode';
 
 function App() {
   const queryClient = new QueryClient();
 
-  const accessToken: string | null = localStorage.getItem("accessToken");
+  //atom setter
   const setIsProfileRegistered = useSetRecoilState(profileRegisteredState);
   const setUserIdx = useSetRecoilState(userIdxState);
-  
-  if(accessToken !== null) {
-    axiosInstance.defaults.headers.common['Authorization'] = `${accessToken}`;
-    localStorage.setItem('accessToken', `${accessToken}`);
-    
-    if(accessToken) {
-      axios.get('/api/members/find')
-        .then((res) => {
-          console.log({res});
-          const userIdx: number | null = res.data.idx;
-          const profileRegistered: boolean = res.data.isprofile;
-          setUserIdx(userIdx);
-          setIsProfileRegistered(profileRegistered);
-        })
-        .catch((err) => {
-          console.error({err});
-        })
-    } 
-  }
+
+  useEffect(()=>{
+    // 초기 1회 토큰 세팅 refresh가 있다면 새로운 access 토큰으로 갱신 (인가처리)
+    // refresh가 정상으로 존재한다면?
+    const accessToken: string | null = localStorage.getItem('accessToken');
+    if(accessToken){
+      HttpClient.post(`/api/auth/token/access`)
+      .then(res => {
+        const token = res?.accessToken;
+        axiosInstance.defaults.headers.common['Authorization'] = `Bearer ${token}`;
+        localStorage.setItem('accessToken', `${token}`);
+      })
+      .catch((error: AxiosError) => {
+        if(error.code === '401'){
+          alert(error.message)
+          return
+        }
+        else if(error.code === '404'){
+          alert(error.message)
+          return
+        }
+        return;
+      });
+    }
+  },[])
+
+  useEffect(() => {
+
+    const accessToken: string | null = localStorage.getItem('accessToken');
+    axiosInstance.interceptors.request.use(
+      async config => {
+        if (accessToken) {
+          try {
+            // 디코딩
+            const parsedToken = accessToken.slice(7);
+            const decodedToken = jwtDecode<JwtPayload>(parsedToken);
+            const currentTime = Date.now() / 1000; // ms -> seconds
+            // 유효성 검증 ( 만료 5분 전을 초과했다면 access 갱신 )
+            if (decodedToken.exp && decodedToken.exp < currentTime + 300) {
+              const data = await HttpClient.post('/api/auth/token/access'); // 유효한 refesh토큰이 헤더에 있다면 정상 동작
+              const token = data.accessToken;
+              config.headers.common['Authorization'] = `Bearer ${token}`; // 갱신된 값으로 설정
+              localStorage.setItem('accessToken', `${token}`); // 로컬스토리지 값도 갱신
+            }
+          } catch (error) {
+            localStorage.removeItem('accessToken'); // refresh 토큰 만료시 로컬스토리지 accessToken 삭제
+            alert('토큰이 만료되었습니다. 다시 로그인 해주세요.');
+            throw error;
+          }
+        }
+
+        return config;
+      },
+      (error: AxiosError) => {
+        return Promise.reject(error);
+      }
+    );
+  }, []);
+
+  useEffect(() => {
+    axios.get('/api/members/find')
+      .then(res => {
+        const userIdx: number | null = res.data.idx;
+        const profileRegistered: boolean = res.data.isprofile;
+        setUserIdx(userIdx); 
+        setIsProfileRegistered(profileRegistered); 
+      })
+      .catch((error: AxiosError) => {
+        console.error(error.message);
+        // return
+      });
+  }, []);
 
   const isMobile = useIsMobile();
-  if(isMobile) return <MobileLanding/>;
+  if (isMobile) return <MobileLanding />;
 
   return (
     <>
-        <QueryClientProvider client={queryClient}>
-          {process.env.NODE_ENV === 'development' && <ReactQueryDevtools initialIsOpen />}
-          <Global styles={globalStyles}/>
-          <Suspense fallback={<div><LottiePageRouting/></div>}>
-            <Container>
-              <Router>
-                <Routes>
-                  <Route path="/" element={<MainPage />}/>
-                  <Route path='/matching' element={<MatchingPage/>}/>
-                  <Route path="/user/kakao-oauth" element={<KaKao />} />
-                  <Route path="/post-profile" element={<PostMyProfile/>} />
-                  <Route path="/put-profile" element={<PutMyProfile/>} />
-                  <Route path="/matchPost/:idx" element={<MatchingPostPage/>} />
-                  <Route path="/others/:userID" element={<OtherProfile/>}/>
-                  <Route path="/post-posting" element={<PostPosting />}/>
-                  <Route path="/put-posting/:idx" element={<PutPosting />}/>
-                  <Route path="/google-callback" element={<GoogleRedirectHandler />}/>
-                  <Route path="/report/:idx" element={<ReportModal />}/>
-                  <Route path="/*" element={<NotFound />}/>
-                </Routes>
-              </Router>
-            </Container>
-          </Suspense>
-        </QueryClientProvider>
+      <QueryClientProvider client={queryClient}>
+        {process.env.NODE_ENV === 'development' && <ReactQueryDevtools initialIsOpen />}
+        <Global styles={globalStyles} />
+        <Suspense
+          fallback={
+            <div>
+              <LottiePageRouting />
+            </div>
+          }
+        >
+          <Container>
+            <Router>
+              <Routes>
+                <Route path="/" element={<MainPage />} />
+                <Route path="/matching" element={<MatchingPage />} />
+                <Route path="/user/kakao-oauth" element={<KaKao />} />
+                <Route path="/post-profile" element={<PostMyProfile />} />
+                <Route path="/put-profile" element={<PutMyProfile />} />
+                <Route path="/matchPost/:idx" element={<MatchingPostPage />} />
+                <Route path="/others/:userID" element={<OtherProfile />} />
+                <Route path="/post-posting" element={<PostPosting />} />
+                <Route path="/put-posting/:idx" element={<PutPosting />} />
+                <Route path="/google-callback" element={<GoogleRedirectHandler />} />
+                <Route path="/report/:idx" element={<ReportModal />} />
+                <Route path="/*" element={<NotFound />} />
+              </Routes>
+            </Router>
+          </Container>
+        </Suspense>
+      </QueryClientProvider>
     </>
   );
 }

--- a/src/components/Common/Header/index.tsx
+++ b/src/components/Common/Header/index.tsx
@@ -1,3 +1,4 @@
+import * as s from "./styles";
 import { Suspense, useEffect, useState } from 'react';
 import { useNavigate, useLocation } from "react-router-dom";
 import HibitLogo from "../../../images/components/HibitLogo.svg";
@@ -6,14 +7,13 @@ import AlarmIcon from "../../../images/components/AlarmIcon.svg";
 import useIsMobile from '../../../hooks/useIsMobile';
 import LoginModal from '../../Login/LoginModal';
 import CustomModalAlarm from '../../Alarm';
-import * as s from "./styles";
-import { useRecoilValue, useRecoilState, useRecoilValueLoadable, useResetRecoilState } from 'recoil';
+import { useRecoilValue, useRecoilState, useResetRecoilState } from 'recoil';
 import { accessTokenState, profileRegisteredState, userIdxState } from '../../../recoil/atom/LoginInfoState';
-import useLoginInfo from '../../../hooks/useLoginInfo';
 import { alarmCountState } from '../../../recoil/atom/AlarmCount';
 import { axiosInstance } from '../../../services/HttpClient';
 import { LoginModalState } from '../../../recoil/atom/LoginModalState';
 import { isLoginAtom } from '../../../recoil/atom/isLoginAtom';
+import { useQueryClient } from '@tanstack/react-query';
 
 const Header = () => {
   const navigate = useNavigate();
@@ -26,20 +26,18 @@ const Header = () => {
   const resetUserIdx = useResetRecoilState(userIdxState);
   const resetIsProfileRegistered = useResetRecoilState(profileRegisteredState);
   
-  // const [modalOpen, setModalOpen] = useState(false);
   const [modalOpen, setModalOpen] = useRecoilState(LoginModalState);
   const closeModal = () => setModalOpen(false);
   const onClickLogin = () => setModalOpen(true);
   
   const [isLogin, setIsLogin] = useRecoilState<boolean>(isLoginAtom);
   let isProfileRegistered: boolean = useRecoilValue(profileRegisteredState);
-  const accessToken: string | null = localStorage.getItem("accessToken");
-  
-  // useEffect(() => {
-  //   if(accessToken) {
-  //     setIsLogin(true);
-  //   }
-  // }, []);
+
+  const queryClient = useQueryClient();
+
+  const removeNicknameCache = () => {
+    queryClient.removeQueries(['nickname']);
+  };
 
   const onClickLogout = async () => {
     await axiosInstance.get(`/api/auth/logout`)
@@ -48,11 +46,10 @@ const Header = () => {
         resetUserIdx();
         resetIsProfileRegistered();
         clearTokenAndHeader();
-
         localStorage.removeItem('accessToken');
-
         setIsLogin(false);
-        // alert("로그아웃 했어요!");
+        alert("로그아웃 했어요!");
+        removeNicknameCache()
         return null;
       })
       .catch((e) => {
@@ -116,7 +113,7 @@ const Header = () => {
         <s.Category onClick={() => onClickIntro()}>서비스 소개</s.Category>
         <s.Category onClick={() => navigate("/matching")}>매칭</s.Category>
         <s.Category
-         onClick={() => {
+        onClick={() => {
           if (isLogin) {
             if (isProfileRegistered) {
               navigate("/put-profile");

--- a/src/components/Common/Header/index.tsx
+++ b/src/components/Common/Header/index.tsx
@@ -13,6 +13,7 @@ import useLoginInfo from '../../../hooks/useLoginInfo';
 import { alarmCountState } from '../../../recoil/atom/AlarmCount';
 import { axiosInstance } from '../../../services/HttpClient';
 import { LoginModalState } from '../../../recoil/atom/LoginModalState';
+import { isLoginAtom } from '../../../recoil/atom/isLoginAtom';
 
 const Header = () => {
   const navigate = useNavigate();
@@ -30,14 +31,15 @@ const Header = () => {
   const closeModal = () => setModalOpen(false);
   const onClickLogin = () => setModalOpen(true);
   
-  const [isLogin, setIsLogin] = useState<boolean>(useLoginInfo());
+  const [isLogin, setIsLogin] = useRecoilState<boolean>(isLoginAtom);
   let isProfileRegistered: boolean = useRecoilValue(profileRegisteredState);
   const accessToken: string | null = localStorage.getItem("accessToken");
-  useEffect(() => {
-    if(accessToken) {
-      setIsLogin(true);
-    }
-  }, []);
+  
+  // useEffect(() => {
+  //   if(accessToken) {
+  //     setIsLogin(true);
+  //   }
+  // }, []);
 
   const onClickLogout = async () => {
     await axiosInstance.get(`/api/auth/logout`)

--- a/src/components/Common/Header/index.tsx
+++ b/src/components/Common/Header/index.tsx
@@ -145,7 +145,8 @@ const Header = () => {
             onRequestClose={onClickAlarm}
           />
           <s.TextWrapper style={{ color: path === '/matching' ? 'white' : 'black'}} onClick={() => onClickLogout()}>로그아웃</s.TextWrapper>
-        </s.RightContainer> :
+        </s.RightContainer> 
+        :
         <s.RightContainer >
           <s.TextWrapper style={{ color: path === '/matching' ? 'white' : 'black'}} onClick={() => onClickLogin()}>회원가입</s.TextWrapper>
           <s.TextWrapper style={{ color: path === '/matching' ? 'white' : 'black'}} onClick={() => onClickLogin()}>로그인</s.TextWrapper>

--- a/src/components/Login/GoogleRedirectHandler/index.tsx
+++ b/src/components/Login/GoogleRedirectHandler/index.tsx
@@ -14,6 +14,7 @@ const GoogleRedirectHandler = () => {
   const setIsProfileRegistered = useSetRecoilState(profileRegisteredState);
   const setUserIdx = useSetRecoilState(userIdxState);
   
+  
   const navigate = useNavigate();
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -26,7 +27,8 @@ const GoogleRedirectHandler = () => {
     axios.post(`${process.env.REACT_APP_SERVER_BASE_HTTPS_URL}/api/auth/google/token`, body, {
       headers: {
         "Content-Type": "application/json"
-      }
+      },
+      withCredentials: true 
     })
       .then((res) => {
         const accessToken: string | null = res.data.accessToken;
@@ -44,9 +46,9 @@ const GoogleRedirectHandler = () => {
           setUserIdx(userIdx);
           setIsProfileRegistered(profileRegistered);
         }
-        console.log({res});
+
         axiosInstance.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
-        localStorage.setItem('accessToken', `Bearer ${accessToken}`);
+        localStorage.setItem('accessToken', `${accessToken}`);
 
         navigate('/');
       })

--- a/src/components/Login/GoogleRedirectHandler/index.tsx
+++ b/src/components/Login/GoogleRedirectHandler/index.tsx
@@ -24,11 +24,16 @@ const GoogleRedirectHandler = () => {
       code: code,
       redirectUri: redirectUri
     }
-    axios.post(`${process.env.REACT_APP_SERVER_BASE_HTTPS_URL}/api/auth/google/token`, body, {
+    // axios.post(`${process.env.REACT_APP_SERVER_BASE_HTTPS_URL}/api/auth/google/token`, body, {
+    //   headers: {
+    //     "Content-Type": "application/json"
+    //   },
+    //   withCredentials: true 
+    // })
+    axiosInstance.post(`${process.env.REACT_APP_SERVER_BASE_HTTPS_URL}/api/auth/google/token`, body, {
       headers: {
         "Content-Type": "application/json"
-      },
-      withCredentials: true 
+      }
     })
       .then((res) => {
         const accessToken: string | null = res.data.accessToken;
@@ -54,6 +59,7 @@ const GoogleRedirectHandler = () => {
       })
       .catch((err) => {
         console.error({err});
+        return
       });
 
     }, [location.search]);

--- a/src/components/MatchPost/PostArticle/index.tsx
+++ b/src/components/MatchPost/PostArticle/index.tsx
@@ -238,6 +238,7 @@ export default function MatchPostArticle({ userLoginInfo ,data, postIDX }: { use
               data.subimg.map((img) => {
                 return (
                   <div 
+                    key={img}
                     css={css`
                       width: 250px;
                       height: 320px;
@@ -608,7 +609,7 @@ export const FsLightboxWrapper = ({ data }: { data?: IMatchingPostPage }) => {
         toggler={toggler}
         sources={
           imgList?.map((img, idx) => {
-            return <img src={img} alt={`img-${idx}`}/>
+            return <img key={img} src={img} alt={`img-${idx}`}/>
           })
         }
       />

--- a/src/components/Matching/SearchBar/index.tsx
+++ b/src/components/Matching/SearchBar/index.tsx
@@ -2,25 +2,35 @@
 import * as s from './styles';
 import { css } from '@emotion/react';
 import COLORS from '../../../assets/color';
-import React, { useState, useRef ,useEffect } from 'react';
+import React, { useState, useRef ,useCallback} from 'react';
 import SearchIcon from '../../../images/components/Matching/searchIcon.svg';
 import { useSetRecoilState } from 'recoil';
 import { MatchingControllerState } from '../../../recoil/atom/MatchingControllerState';
 import HttpClient from '../../../services/HttpClient';
+import { useQuery } from '@tanstack/react-query';
+
+
+interface IUsersMe {
+  "id": number,
+  "email": string,
+  "nickname": string,
+  "profileImageUrl": string,
+  "socialType": "GOOGLE",
+}
 
 const CustomSearchBar = () => {
-  let [userId,setUserId] = useState<string>('');
-  useEffect(() => {
-    const fetchUserId = async () => {
-      try {
-        const fetchedUserId = await HttpClient.get('/api/profiles/me');
-        setUserId(fetchedUserId.nickname);
-      } catch (e) {
-        console.error(e,'userId를 받아오지 못했습니다.');
-      }
-    };
-    fetchUserId()
-  },[userId])
+
+  const fetchUserId = useCallback( async () => {
+    const fetchedUserId = await HttpClient.get('/api/profiles/me');
+    return fetchedUserId
+  },[])
+
+  const {data, isError} = useQuery<IUsersMe>(['nickname'],fetchUserId)
+  
+  if(isError){
+    console.error('nickname fetch failed')
+  }
+  
   const inputRef = useRef<HTMLInputElement>(null);
   const [inputValue, setInputValue] = useState('');
   const [placeHolderState, setPlaceHolderState] = useState(true);
@@ -56,7 +66,7 @@ const CustomSearchBar = () => {
             font-weight: 700;
           `}
         >
-          {userId ? userId : '익명'}
+          {data?.nickname ? data?.nickname  : '익명'}
         </span>
         님 👋
       </span>

--- a/src/components/Matching/SearchBar/index.tsx
+++ b/src/components/Matching/SearchBar/index.tsx
@@ -8,6 +8,7 @@ import { useSetRecoilState } from 'recoil';
 import { MatchingControllerState } from '../../../recoil/atom/MatchingControllerState';
 import HttpClient from '../../../services/HttpClient';
 import { useQuery } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
 
 
 interface IUsersMe {
@@ -25,10 +26,16 @@ const CustomSearchBar = () => {
     return fetchedUserId
   },[])
 
-  const {data, isError} = useQuery<IUsersMe>(['nickname'],fetchUserId)
-  
-  if(isError){
-    console.error('nickname fetch failed')
+  const {data, isError, error} = useQuery<IUsersMe>(['nickname'],fetchUserId,{
+    refetchOnWindowFocus: false,
+    retry: 1,
+  })
+
+  if( isError && error instanceof AxiosError){
+    const status = error.response?.status;
+    if (status !== 401){ // not authorized 제외
+      console.error('nickname fetch failed')
+    }
   }
   
   const inputRef = useRef<HTMLInputElement>(null);

--- a/src/hooks/MatchingPost/usePostReplyLikeMutation.ts
+++ b/src/hooks/MatchingPost/usePostReplyLikeMutation.ts
@@ -8,7 +8,6 @@ export const usePostReplyLikeMutation = (replyIDX: number | undefined) => {
   const queryClient = useQueryClient();
   const isProfile = useRecoilValue<boolean>(profileRegisteredState)
   const replyLikeMutationFn = async (replyIDX: number | undefined) => {
-      if(!isProfile) throw Error
       const path = `/comment/like/${replyIDX}`;
       const res = await HttpClient.get(path);
       return res;
@@ -19,7 +18,6 @@ export const usePostReplyLikeMutation = (replyIDX: number | undefined) => {
     },
     onError: e => {
       console.error(`${replyIDX}번 댓글의 좋아요에 실패했습니다. error : ${(e as AxiosError).message}`);
-      alert('좋아요에 실패했습니다.')
     },
   });
 };

--- a/src/hooks/MathchingMain/useGetMatchingInifiniteQuery.ts
+++ b/src/hooks/MathchingMain/useGetMatchingInifiniteQuery.ts
@@ -37,6 +37,7 @@ export const useGetMatchingInfiniteQuery = () => {
     getNextPageParam: (lastPage, allPages) => {
       return lastPage.length ? allPages.length + 1 : undefined;
     },
-    refetchOnWindowFocus: true,
+    retry:1,
+    staleTime: 30 * 1000,
   });
 };

--- a/src/hooks/MathchingMain/useGetMatchingInifiniteQuery.ts
+++ b/src/hooks/MathchingMain/useGetMatchingInifiniteQuery.ts
@@ -37,7 +37,6 @@ export const useGetMatchingInfiniteQuery = () => {
     getNextPageParam: (lastPage, allPages) => {
       return lastPage.length ? allPages.length + 1 : undefined;
     },
-    staleTime: 1000 * 45,  
-    refetchOnWindowFocus: false,
+    refetchOnWindowFocus: true,
   });
 };

--- a/src/pages/MatchPost/index.tsx
+++ b/src/pages/MatchPost/index.tsx
@@ -61,13 +61,13 @@ export default function MatchingPostPage() {
   }, [idx, setIdxAtom]);
 
   const getPostInfoFn = async () => {
-    // try {
+    try {
       const res = await HttpClient.get(`/post/${idx}`);
       return res;
-    // } catch (e) {
-      // console.error(`게시글 정보를 불러오지 못했습니다 : ${(e as AxiosError).message}`);
-      // return;
-    // }
+    } catch (e) {
+      console.error(`게시글 정보를 불러오지 못했습니다 : ${(e as AxiosError).message}`);
+      return;
+    }
   };
   const { data, isError, error, isLoading, isFetching, status } = useQuery<IMatchingPostPage, AxiosError>(['post-info'], getPostInfoFn);
 

--- a/src/pages/MatchPost/index.tsx
+++ b/src/pages/MatchPost/index.tsx
@@ -61,19 +61,15 @@ export default function MatchingPostPage() {
   }, [idx, setIdxAtom]);
 
   const getPostInfoFn = async () => {
-    try {
+    // try {
       const res = await HttpClient.get(`/post/${idx}`);
       return res;
-    } catch (e) {
-      console.error(`게시글 정보를 불러오지 못했습니다 : ${(e as AxiosError).message}`);
-      return;
-    }
+    // } catch (e) {
+      // console.error(`게시글 정보를 불러오지 못했습니다 : ${(e as AxiosError).message}`);
+      // return;
+    // }
   };
-  const { data, isError, error, isLoading, isFetching, status } = useQuery<IMatchingPostPage, AxiosError>(['post-info'], getPostInfoFn, {
-    staleTime: 1000,
-    retry: 1,
-    retryDelay: 2000,
-  },);
+  const { data, isError, error, isLoading, isFetching, status } = useQuery<IMatchingPostPage, AxiosError>(['post-info'], getPostInfoFn);
 
   useEffect(() => {
     window.scrollTo(0, 100); // x축은 0, y축은 0으로 설정하여 상단으로 스크롤

--- a/src/pages/Matching/index.tsx
+++ b/src/pages/Matching/index.tsx
@@ -28,9 +28,6 @@ const MatchingPage = () => {
     fetchNextPage,
     isFetching,
     hasNextPage,
-    // isFetchingPreviousPage,
-    // fetchPreviousPage,
-    // hasPreviousPage,
   } = useGetMatchingInfiniteQuery();
 
   if (isError === true) {

--- a/src/pages/MyProfile/PostMyProfile/index.tsx
+++ b/src/pages/MyProfile/PostMyProfile/index.tsx
@@ -18,6 +18,7 @@ import { useSetRecoilState } from "recoil";
 import { profileRegisteredState, userIdxState } from "../../../recoil/atom/LoginInfoState";
 import axios from "axios";
 import GoogleTagManager from "../../../components/TagManager";
+import HttpClient from "../../../services/HttpClient";
 
 const PostMyProfile = () => {
   const [isEditMode, setIsEditMode] = useState<boolean>(true);
@@ -32,15 +33,15 @@ const PostMyProfile = () => {
 
   useEffect(() => {
     if(accessToken) {
-      axios.get('/api/members/find')
+      HttpClient.get('/api/members/find')
         .then((res) => {
           console.log({res});
-          const userIdx: number | null = res.data.idx;
-          const profileRegistered: boolean = res.data.isprofile;
+          const userIdx: number | null = res.idx;
+          const profileRegistered: boolean = res.isprofile;
           setUserIdx(userIdx);
           setIsProfileRegistered(profileRegistered);
 
-          console.log(res.data.isprofile)
+          console.log(res.isprofile)
           if(res.data.isprofile) {
             console.log("프로필정보가 등록되어 있어 put-profile로 이동");
             navigate("/put-profile");

--- a/src/pages/MyProfile/PostMyProfile/index.tsx
+++ b/src/pages/MyProfile/PostMyProfile/index.tsx
@@ -18,7 +18,7 @@ import { useSetRecoilState } from "recoil";
 import { profileRegisteredState, userIdxState } from "../../../recoil/atom/LoginInfoState";
 import axios from "axios";
 import GoogleTagManager from "../../../components/TagManager";
-import HttpClient from "../../../services/HttpClient";
+import HttpClient, { axiosInstance } from "../../../services/HttpClient";
 
 const PostMyProfile = () => {
   const [isEditMode, setIsEditMode] = useState<boolean>(true);
@@ -33,15 +33,15 @@ const PostMyProfile = () => {
 
   useEffect(() => {
     if(accessToken) {
-      HttpClient.get('/api/members/find')
+      axiosInstance.get('/api/members/find')
         .then((res) => {
           console.log({res});
-          const userIdx: number | null = res.idx;
-          const profileRegistered: boolean = res.isprofile;
+          const userIdx: number | null = res.data?.idx;
+          const profileRegistered: boolean = res.data?.isprofile;
           setUserIdx(userIdx);
           setIsProfileRegistered(profileRegistered);
 
-          console.log(res.isprofile)
+          console.log(res.data?.isprofile)
           if(res.data.isprofile) {
             console.log("프로필정보가 등록되어 있어 put-profile로 이동");
             navigate("/put-profile");

--- a/src/pages/MyProfile/PutMyProfile/index.tsx
+++ b/src/pages/MyProfile/PutMyProfile/index.tsx
@@ -34,17 +34,14 @@ const PutMyProfile = () => {
   const setUserIdx = useSetRecoilState(userIdxState);
 
   if(accessToken !== null) {
-    // axiosInstance.defaults.headers.common['Authorization'] = `${accessToken}`;
-    // localStorage.setItem('accessToken', `${accessToken}`);
-    
     if(accessToken) {
-      HttpClient.get('/api/members/find')
+      axiosInstance.get('/api/members/find')
         .then((res) => {
-          const userIdx: number | null = res.idx;
-          const profileRegistered: boolean = res.isprofile;
+          const userIdx: number | null = res.data?.idx;
+          const profileRegistered: boolean = res.data?.isprofile;
           setUserIdx(userIdx);
           setIsProfileRegistered(profileRegistered);
-          if(!res.isprofile) {
+          if(!res.data?.isprofile) {
             console.log("프로필정보가 등록되어 있지 않아 post-profile로 이동");
             navigate("/post-profile");
           }

--- a/src/pages/MyProfile/PutMyProfile/index.tsx
+++ b/src/pages/MyProfile/PutMyProfile/index.tsx
@@ -19,6 +19,7 @@ import { useRecoilValue, useSetRecoilState } from "recoil";
 import { profileRegisteredState, userIdxState } from "../../../recoil/atom/LoginInfoState";
 import axios from "axios";
 import { axiosInstance } from "../../../services/HttpClient";
+import HttpClient from "../../../services/HttpClient";
 
 const PutMyProfile = () => {
   const [isEditMode, setIsEditMode] = useState<boolean>(false);
@@ -33,17 +34,17 @@ const PutMyProfile = () => {
   const setUserIdx = useSetRecoilState(userIdxState);
 
   if(accessToken !== null) {
-    axiosInstance.defaults.headers.common['Authorization'] = `${accessToken}`;
-    localStorage.setItem('accessToken', `${accessToken}`);
+    // axiosInstance.defaults.headers.common['Authorization'] = `${accessToken}`;
+    // localStorage.setItem('accessToken', `${accessToken}`);
     
     if(accessToken) {
-      axiosInstance.get('/api/members/find')
+      HttpClient.get('/api/members/find')
         .then((res) => {
-          const userIdx: number | null = res.data.idx;
-          const profileRegistered: boolean = res.data.isprofile;
+          const userIdx: number | null = res.idx;
+          const profileRegistered: boolean = res.isprofile;
           setUserIdx(userIdx);
           setIsProfileRegistered(profileRegistered);
-          if(!res.data.isprofile) {
+          if(!res.isprofile) {
             console.log("프로필정보가 등록되어 있지 않아 post-profile로 이동");
             navigate("/post-profile");
           }

--- a/src/recoil/atom/isLoginAtom.ts
+++ b/src/recoil/atom/isLoginAtom.ts
@@ -1,0 +1,6 @@
+import { atom } from "recoil";
+
+export const isLoginAtom = atom<boolean>({
+  key: 'isLoginAtom',
+  default: false,
+});


### PR DESCRIPTION
## 작업 내용
> 서버에서 응답받은 refresh token cookie로 access token을 갱신하는 로직을 작업.

<br/>

## 변동 내용
> 기존의 루트컴포넌트에 작성되어 있던 인가처리 로직을 대거 수정했습니다.

**1. 로컬 스토리지의 access token을 decode하여 payload의 만료기한을 추출한 뒤, 만료 5분전에 access token 갱신시키는 로직으로 개선.**
( ** axios intercepter** 를 활용하여 초기 앱 로드시 모든 axios_Instansce 요청에 유효성 검사가 실행되도록 로직을 구성했습니다.)

2. [부가작업] search bar에 표기되는 닉네임 fetch 로직을 react query로 리팩토링 한 뒤, 로그아웃시 query  cache가 삭제되도록 만들었습니다.

## 처리 결과:
1. 서비스 사용 도중 access token이 만료 되더라도 인가처리가 끊어지지 않습니다.
2. 재접속시 인가처리가 끊어지지 않습니다.
3. 다른 페이지로 이동후 다시 돌아와도 인가처리가 끊어지지 않습니다.
4. access token 기한 만료 이후 사이트 재접속 시에도 쿠키상 refresh token이 유효하다면 access token 갱신 요청을 통해 인가처리가 끊어지지 않습니다.

<br/>

## 자료 첨부
> 없음

<br/>

## 중점으로 리뷰받고 싶은 내용
> 1. 현재 자체적으로 테스트해서 문제가 없어 보이는데, 실제로 서버상에서 토큰 유효기한을 짧게 변경해서 테스트 및 검증이 필요할 것 같습니다. 

<br/>

## 참고자료
> 없음
